### PR TITLE
Add additional methods for querying MarkLogic content

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
@@ -49,6 +49,20 @@ public class AbstractMarkLogicIT {
     protected String threadCount = "3";
     protected String databaseClientServiceIdentifier = "databaseClientService";
     protected int numDocs = 30;
+
+    protected int xmlMod = 5;
+    protected int jsonMod = 3;
+    protected int txtMod = 7;
+
+    // mod  xmlMod == 0 docs are XML
+    protected int expectedXmlCount = (int) (Math.ceil((numDocs - 1.0) / xmlMod));
+    // mod jsonMod == 0 docs are JSON, but mod xmlMod == 0 docs are XML and take precedence in doc generation
+    protected int expectedJsonCount = (int) (Math.ceil((numDocs - 1.0) / jsonMod) - Math.ceil((numDocs - 1.0) / (xmlMod * jsonMod)));
+    // mod txtMod == 0 docs are Text, but mod xmlMod == 0 docs are XML and mod jsonMod == 0 docs are JSON and both take precedence in doc generation
+    protected int expectedTxtCount = (int) (Math.ceil((numDocs - 1.0) / txtMod) - Math.ceil((numDocs - 1.0) / (txtMod * jsonMod)) - Math.ceil((numDocs - 1.0) / (txtMod * xmlMod)));
+    // binary documents make up the remainder
+    protected int expectedBinCount = numDocs - (expectedXmlCount + expectedJsonCount + expectedTxtCount);
+
     protected DatabaseClient client;
     protected DataMovementManager dataMovementManager;
 
@@ -90,13 +104,13 @@ public class AbstractMarkLogicIT {
         for(int i = 0; i < numDocs; i++) {
             String fileName = "/PutMarkLogicTest/";
             String content = "";
-            if(i % 5 == 0) {
+            if(i % xmlMod == 0) {
                 fileName += i + ".xml";
                 content = "<sample>xmlcontent</sample>";
-            } else if ( i % 3 == 0) {
+            } else if ( i % jsonMod == 0) {
                 fileName += i + ".json";
                 content = "{\"sample\":\"jsoncontent\"}";
-            } else if (i % 7 == 0) {
+            } else if (i % txtMod == 0) {
                 fileName += i + ".txt";
                 content = "A sample text document";
             } else {

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
@@ -29,9 +29,17 @@ import org.apache.nifi.util.TestRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -78,6 +86,28 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     @Test
     public void testSimpleCollectionQuery() throws InitializationException {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
+        runner.setProperty(QueryMarkLogic.QUERY, collection);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COLLECTION.name());
+        runner.assertValid();
+        runner.run();
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, numDocs);
+        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
+        byte[] actualByteArray = null;
+        for(MockFlowFile flowFile : flowFiles) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("3.json")) {
+                actualByteArray = runner.getContentAsByteArray(flowFile);
+                break;
+            }
+        }
+        byte[] expectedByteArray = documents.get(3).getContent().getBytes();
+        assertEquals(expectedByteArray.length, actualByteArray.length);
+        assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
+    }
+
+    @Test
+    public void testOldCollectionQuery() throws InitializationException {
+        TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.COLLECTIONS, collection);
         runner.assertValid();
         runner.run();
@@ -97,9 +127,168 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     }
 
     @Test
+    public void testCombinedJSONQuery() throws InitializationException {
+        TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
+        runner.setProperty(QueryMarkLogic.QUERY, "{\"search\" : {\n" +
+                "  \"ctsquery\": {\n" +
+                "    \"jsonPropertyValueQuery\":{\n" +
+                "      \"property\":[\"sample\"],\n" +
+                "      \"value\":[\"jsoncontent\"]\n" +
+                "      } \n" +
+                "  }\n" +
+                "} }");
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_JSON.name());
+        runner.assertValid();
+        runner.run();
+        // mod 3 == 0 docs are JSON, but mod 5 == 0 docs are XML and take precedence in doc generation
+        int expectedSize = (int) (Math.ceil((numDocs - 1.0) / 3.0) - Math.ceil((numDocs - 1.0) / 15.0));
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
+        assertEquals(flowFiles.size(), expectedSize);
+        byte[] actualByteArray = null;
+        for(MockFlowFile flowFile : flowFiles) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("3.json")) {
+                actualByteArray = runner.getContentAsByteArray(flowFile);
+                break;
+            }
+        }
+        byte[] expectedByteArray = documents.get(3).getContent().getBytes();
+        assertEquals(expectedByteArray.length, actualByteArray.length);
+        assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
+        runner.shutdown();
+    }
+
+    @Test
+    public void testCombinedXMLQuery() throws InitializationException, SAXException, IOException, ParserConfigurationException {
+        TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
+        runner.setProperty(QueryMarkLogic.QUERY, "<cts:element-value-query xmlns:cts=\"http://marklogic.com/cts\">\n" +
+                "  <cts:element>sample</cts:element>\n" +
+                "  <cts:text xml:lang=\"en\">xmlcontent</cts:text>\n" +
+                "</cts:element-value-query>");
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_XML.name());
+        runner.assertValid();
+        runner.run();
+        // mod 5 == 0 docs are generated as XML
+        int expectedSize = (int) Math.ceil((numDocs - 1.0) / 5.0);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
+        assertEquals(flowFiles.size(), expectedSize);
+        byte[] actualByteArray = null;
+        for(MockFlowFile flowFile : flowFiles) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/5.xml")) {
+                actualByteArray = runner.getContentAsByteArray(flowFile);
+                break;
+            }
+        }
+        byte[] expectedByteArray = documents.get(5).getContent().getBytes();
+
+        assertBytesAreEqualXMLDocs(expectedByteArray,actualByteArray);
+        runner.shutdown();
+    }
+
+    @Test
+    public void testStructuredJSONQuery() throws InitializationException {
+        TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
+        runner.setProperty(QueryMarkLogic.QUERY, "{\n" +
+                "  \"query\": {\n" +
+                "    \"queries\": [\n" +
+                "      { \n" +
+                "       \"value-query\": {\n" +
+                "          \"type\": \"string\",\n" +
+                "          \"json-property\": [\"sample\"],\n" +
+                "          \"text\": [\"jsoncontent\"]\n" +
+                "        }" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}");
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_JSON.name());
+        runner.assertValid();
+        runner.run();
+        // mod 3 == 0 docs are JSON, but mod 5 == 0 docs are XML and take precedence in doc generation
+        int expectedSize = (int) (Math.ceil((numDocs - 1.0) / 3.0) - Math.ceil((numDocs - 1.0) / 15.0));
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
+        assertEquals(flowFiles.size(), expectedSize);
+        byte[] actualByteArray = null;
+        for(MockFlowFile flowFile : flowFiles) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("3.json")) {
+                actualByteArray = runner.getContentAsByteArray(flowFile);
+                break;
+            }
+        }
+        byte[] expectedByteArray = documents.get(3).getContent().getBytes();
+        assertEquals(expectedByteArray.length, actualByteArray.length);
+        assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
+        runner.shutdown();
+    }
+
+    @Test
+    public void testStructuredXMLQuery() throws InitializationException, SAXException, IOException, ParserConfigurationException {
+        TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
+        runner.setProperty(QueryMarkLogic.QUERY, "<query xmlns=\"http://marklogic.com/appservices/search\">\n" +
+                "  <word-query>\n" +
+                "    <element name=\"sample\" ns=\"\" />\n" +
+                "    <text>xmlcontent</text>\n" +
+                "  </word-query>\n" +
+                "</query>");
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_XML.name());
+        runner.assertValid();
+        runner.run();
+        // mod 5 == 0 docs are generated as XML
+        int expectedSize = (int) Math.ceil((numDocs - 1.0) / 5.0);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
+        assertEquals(flowFiles.size(), expectedSize);
+        byte[] actualByteArray = null;
+        for(MockFlowFile flowFile : flowFiles) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/5.xml")) {
+                actualByteArray = runner.getContentAsByteArray(flowFile);
+                break;
+            }
+        }
+        byte[] expectedByteArray = documents.get(5).getContent().getBytes();
+
+        assertBytesAreEqualXMLDocs(expectedByteArray,actualByteArray);
+        runner.shutdown();
+    }
+
+
+    @Test
+    public void testStringQuery() throws InitializationException, SAXException, IOException, ParserConfigurationException {
+        TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
+        runner.setProperty(QueryMarkLogic.QUERY, "xmlcontent");
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING.name());
+        runner.assertValid();
+        runner.run();
+        // mod 5 == 0 docs are generated as XML
+        int expectedSize = (int) Math.ceil((numDocs - 1.0) / 5.0);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
+        assertEquals(flowFiles.size(), expectedSize);
+        byte[] actualByteArray = null;
+        for(MockFlowFile flowFile : flowFiles) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/5.xml")) {
+                actualByteArray = runner.getContentAsByteArray(flowFile);
+                break;
+            }
+        }
+        byte[] expectedByteArray = documents.get(5).getContent().getBytes();
+
+        assertBytesAreEqualXMLDocs(expectedByteArray,actualByteArray);
+        runner.shutdown();
+    }
+
+    @Test
     public void testJobProperties() throws InitializationException {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
-        runner.setProperty(QueryMarkLogic.COLLECTIONS, collection);
+        runner.setProperty(QueryMarkLogic.QUERY, collection);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COLLECTION.name());
         runner.run();
         Processor processor = runner.getProcessor();
         if(processor instanceof QueryMarkLogic) {
@@ -109,5 +298,23 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         } else {
             fail("Processor not an instance of QueryMarkLogic");
         }
+        runner.shutdown();
+    }
+
+    private void assertBytesAreEqualXMLDocs(byte[] expectedByteArray, byte[] actualByteArray) throws SAXException, IOException, ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        dbf.setCoalescing(true);
+        dbf.setIgnoringElementContentWhitespace(true);
+        dbf.setIgnoringComments(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+
+        Document doc1 = db.parse(new ByteArrayInputStream(actualByteArray));
+        doc1.normalizeDocument();
+
+        Document doc2 = db.parse(new ByteArrayInputStream(expectedByteArray));
+        doc2.normalizeDocument();
+
+        assertTrue(doc1.isEqualNode(doc2));
     }
 }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
@@ -95,12 +95,12 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
         byte[] actualByteArray = null;
         for(MockFlowFile flowFile : flowFiles) {
-            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("3.json")) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/" + Integer.toString(jsonMod) + ".json")) {
                 actualByteArray = runner.getContentAsByteArray(flowFile);
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(3).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
     }
@@ -116,12 +116,12 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
         byte[] actualByteArray = null;
         for(MockFlowFile flowFile : flowFiles) {
-            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("3.json")) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/" + Integer.toString(jsonMod) + ".json")) {
                 actualByteArray = runner.getContentAsByteArray(flowFile);
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(3).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
     }
@@ -140,20 +140,18 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_JSON.name());
         runner.assertValid();
         runner.run();
-        // mod 3 == 0 docs are JSON, but mod 5 == 0 docs are XML and take precedence in doc generation
-        int expectedSize = (int) (Math.ceil((numDocs - 1.0) / 3.0) - Math.ceil((numDocs - 1.0) / 15.0));
-        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedJsonCount);
         runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
-        assertEquals(flowFiles.size(), expectedSize);
+        assertEquals(flowFiles.size(), expectedJsonCount);
         byte[] actualByteArray = null;
         for(MockFlowFile flowFile : flowFiles) {
-            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("3.json")) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/" + Integer.toString(jsonMod) + ".json")) {
                 actualByteArray = runner.getContentAsByteArray(flowFile);
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(3).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
         runner.shutdown();
@@ -169,20 +167,18 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_XML.name());
         runner.assertValid();
         runner.run();
-        // mod 5 == 0 docs are generated as XML
-        int expectedSize = (int) Math.ceil((numDocs - 1.0) / 5.0);
-        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedXmlCount);
         runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
-        assertEquals(flowFiles.size(), expectedSize);
+        assertEquals(flowFiles.size(), expectedXmlCount);
         byte[] actualByteArray = null;
         for(MockFlowFile flowFile : flowFiles) {
-            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/5.xml")) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/"+ Integer.toString(xmlMod) +".xml")) {
                 actualByteArray = runner.getContentAsByteArray(flowFile);
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(5).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes();
 
         assertBytesAreEqualXMLDocs(expectedByteArray,actualByteArray);
         runner.shutdown();
@@ -207,20 +203,18 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_JSON.name());
         runner.assertValid();
         runner.run();
-        // mod 3 == 0 docs are JSON, but mod 5 == 0 docs are XML and take precedence in doc generation
-        int expectedSize = (int) (Math.ceil((numDocs - 1.0) / 3.0) - Math.ceil((numDocs - 1.0) / 15.0));
-        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedJsonCount);
         runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
-        assertEquals(flowFiles.size(), expectedSize);
+        assertEquals(flowFiles.size(), expectedJsonCount);
         byte[] actualByteArray = null;
         for(MockFlowFile flowFile : flowFiles) {
-            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("3.json")) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/" + Integer.toString(jsonMod) + ".json")) {
                 actualByteArray = runner.getContentAsByteArray(flowFile);
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(3).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
         runner.shutdown();
@@ -238,20 +232,18 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_XML.name());
         runner.assertValid();
         runner.run();
-        // mod 5 == 0 docs are generated as XML
-        int expectedSize = (int) Math.ceil((numDocs - 1.0) / 5.0);
-        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedXmlCount);
         runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
-        assertEquals(flowFiles.size(), expectedSize);
+        assertEquals(flowFiles.size(), expectedXmlCount);
         byte[] actualByteArray = null;
         for(MockFlowFile flowFile : flowFiles) {
-            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/5.xml")) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/"+ Integer.toString(xmlMod) +".xml")) {
                 actualByteArray = runner.getContentAsByteArray(flowFile);
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(5).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes();
 
         assertBytesAreEqualXMLDocs(expectedByteArray,actualByteArray);
         runner.shutdown();
@@ -265,20 +257,18 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING.name());
         runner.assertValid();
         runner.run();
-        // mod 5 == 0 docs are generated as XML
-        int expectedSize = (int) Math.ceil((numDocs - 1.0) / 5.0);
-        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedSize);
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedXmlCount);
         runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS);
-        assertEquals(flowFiles.size(), expectedSize);
+        assertEquals(flowFiles.size(), expectedXmlCount);
         byte[] actualByteArray = null;
         for(MockFlowFile flowFile : flowFiles) {
-            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/5.xml")) {
+            if(flowFile.getAttribute(CoreAttributes.FILENAME.key()).endsWith("/"+ Integer.toString(xmlMod) +".xml")) {
                 actualByteArray = runner.getContentAsByteArray(flowFile);
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(5).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes();
 
         assertBytesAreEqualXMLDocs(expectedByteArray,actualByteArray);
         runner.shutdown();


### PR DESCRIPTION
Query Types Available: 
- COLLECTION("Collection Query")
- COMBINED_JSON("Combined Query (JSON)"),
- COMBINED_XML("Combined Query (XML)"),
- STRING("String Query"),
- STRUCTURED_JSON("Structured Query (JSON)"),
- STRUCTURED_XML("Structured Query (XML)")

The default type is COMBINED_JSON. 

Also, the old `Collections` property method is preserved, but deprecated.