### PR TITLE
#64 Permissions are now evaluated against FlowFile attributes

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
@@ -136,6 +136,7 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         .defaultValue("rest-reader,read,rest-writer,update")
         .description("Comma-delimited sequence of permissions - role1, capability1, role2, " +
             "capability2 - to add to each document")
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .addValidator(Validator.VALID)
         .required(false)
         .build();
@@ -390,13 +391,19 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         metadata.withCollections(collections);
 
         // Get permission from processor property definition
-        final String permissionsValue = permissionsProperty.getValue();
+        final String permissionsValue = permissionsProperty.isSet() ?
+            permissionsProperty.evaluateAttributeExpressions(flowFile).getValue() : null;
         final String[] tokens = getArrayFromCommaSeparatedString(permissionsValue);
         if (tokens != null) {
+            DocumentMetadataHandle.DocumentPermissions permissions = metadata.getPermissions();
             for (int i = 0; i < tokens.length; i += 2) {
                 String role = tokens[i];
-                String capability = tokens[i + 1];
-                metadata.withPermission(role, DocumentMetadataHandle.Capability.getValueOf(capability));
+                DocumentMetadataHandle.Capability capability = DocumentMetadataHandle.Capability.getValueOf(tokens[i + 1]);
+                if (permissions.containsKey(role)) {
+                    permissions.get(role).add(capability);
+                } else {
+                    permissions.add(role, capability);
+                }
             }
         }
         String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.marklogic.processor;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.nifi.marklogic.controller.DefaultMarkLogicDatabaseClientService;
@@ -71,7 +73,11 @@ public class AbstractMarkLogicProcessorTest extends Assert {
     }
 
     protected MockFlowFile addFlowFile(String... contents) {
-        MockFlowFile flowFile = processSession.createFlowFile(String.join("\n", contents).getBytes());
+        return addFlowFile(new HashMap(), contents);
+    }
+
+    protected MockFlowFile addFlowFile(Map<String, String> attributes, String... contents) {
+        MockFlowFile flowFile = processSession.createFlowFile(String.join("\n", contents).getBytes(), attributes);
         sharedSessionState.getFlowFileQueue().offer(flowFile);
         return flowFile;
     }


### PR DESCRIPTION
This addresses https://github.com/marklogic/nifi/issues/64 , which is a bug where permissions with the same role were not supported, in addition to allowing for permissions to be evaluated against FlowFile attributes. 

