### PR TITLE
94 Fix failing tests for 1.9.1.5

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
@@ -267,7 +267,6 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         getLogger().info("OnScheduled");
         super.populatePropertiesByPrefix(context);
         try {
-            DatabaseClient client = getDatabaseClient(context);
             dataMovementManager = getDatabaseClient(context).newDataMovementManager();
             writeBatcher = dataMovementManager.newWriteBatcher()
                     .withJobId(context.getProperty(JOB_ID).getValue())

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
@@ -267,9 +267,13 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
                 session.transfer(incomingFlowFile, ORIGINAL);
             }
 
+            getLogger().info("Starting job");
             dataMovementManager.startJob(queryBatcher);
+            getLogger().info("Awaiting job completion");
             queryBatcher.awaitCompletion();
+            getLogger().info("Stopping job");
             dataMovementManager.stopJob(queryBatcher);
+            getLogger().info("Committing session");
             session.commit();
         } catch (final Throwable t) {
             context.yield();

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
@@ -47,7 +47,7 @@ import static junit.framework.TestCase.assertTrue;
  * The test database is cleared before every test is run so that no "residue" is left behind.
  */
 @ContextConfiguration(classes = {TestConfig.class})
-public class AbstractMarkLogicIT extends AbstractSpringMarkLogicTest {
+public abstract class AbstractMarkLogicIT extends AbstractSpringMarkLogicTest {
 
     @Autowired
     protected TestConfig testConfig;

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class AbstractMarkLogicProcessorTest extends Assert {
+public abstract class AbstractMarkLogicProcessorTest extends Assert {
     Processor processor;
     protected MockProcessContext processContext;
     protected MockProcessorInitializationContext initializationContext;

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogicIT.java
@@ -16,14 +16,6 @@
  */
 package org.apache.nifi.marklogic.processor;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
-
-import org.apache.nifi.flowfile.attributes.CoreAttributes;
-import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.util.TestRunner;
-
 import com.marklogic.client.datamovement.WriteBatcher;
 import com.marklogic.client.document.DocumentPage;
 import com.marklogic.client.io.DocumentMetadataHandle;
@@ -31,12 +23,17 @@ import com.marklogic.client.io.Format;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
-import org.junit.jupiter.api.AfterEach;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
 public class ApplyTransformMarkLogicIT extends AbstractMarkLogicIT {
+
     private String collection;
     private QueryManager queryMgr;
 
@@ -44,47 +41,12 @@ public class ApplyTransformMarkLogicIT extends AbstractMarkLogicIT {
     public void setup() {
         super.setup();
         collection = "ApplyTransformMarkLogicTest";
-        // Load documents to Query
-        loadDocumentsIntoCollection(collection, documents);
         queryMgr = getDatabaseClient().newQueryManager();
-        getDatabaseClient().newServerConfigManager()
-            .newTransformExtensionsManager()
-            .writeXSLTransform(
-                "AddAttribute",
-                new StringHandle().with("<xsl:stylesheet version=\"2.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"\n" +
-                        "    xmlns:example=\"http://marklogic.com/rest-api/example/transform\"\n" +
-                        "    xmlns:map=\"http://marklogic.com/xdmp/map\">\n" +
-                        "<xsl:param name=\"context\" as=\"map:map\"/>\n" +
-                        "<xsl:param name=\"params\"  as=\"map:map\"/>\n" +
-                        "<xsl:template match=\"/*\">\n" +
-                        "    <xsl:copy>\n" +
-                        "        <xsl:attribute name='{(map:get($params,\"name\"),\"transformed\")[1]}'\n" +
-                        "            select='(map:get($params,\"value\"),\"UNDEFINED\")[1]'/>\n" +
-                        "        <xsl:copy-of select=\"@*\"/>\n" +
-                        "        <xsl:copy-of select=\"node()\"/>\n" +
-                        "    </xsl:copy>\n" +
-                        "</xsl:template>\n" +
-                        "</xsl:stylesheet>")
-            );
-    }
-
-    private void loadDocumentsIntoCollection(String collection, List<IngestDoc> documents) {
-        WriteBatcher writeBatcher = dataMovementManager.newWriteBatcher()
-            .withBatchSize(3)
-            .withThreadCount(3);
-        dataMovementManager.startJob(writeBatcher);
-        for(IngestDoc document : documents) {
-            DocumentMetadataHandle handle = new DocumentMetadataHandle();
-            handle.withCollections(collection);
-            writeBatcher.add(document.getFileName(), handle, new StringHandle(document.getContent()));
-        }
-        writeBatcher.flushAndWait();
-        dataMovementManager.stopJob(writeBatcher);
+        loadDocumentsIntoCollection(collection, documents);
     }
 
     @Test
-    @Disabled("Will fix in separate PR")
-    public void testApplyTransform() throws InitializationException {
+    public void testApplyTransform() {
         TestRunner runner = getNewTestRunner(ApplyTransformMarkLogic.class);
         runner.setValidateExpressionUsage(false);
         String queryStr = "<cts:element-value-query xmlns:cts=\"http://marklogic.com/cts\">\n" +
@@ -99,7 +61,7 @@ public class ApplyTransformMarkLogicIT extends AbstractMarkLogicIT {
         runner.assertValid();
         runner.run();
         runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedXmlCount);
-        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS,CoreAttributes.FILENAME.key());
+        runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS, CoreAttributes.FILENAME.key());
         StringHandle queryHandle = new StringHandle().withFormat(Format.XML).with(queryStr);
         RawCombinedQueryDefinition qDef = queryMgr.newRawCombinedQueryDefinition(queryHandle);
         DocumentPage page = getDatabaseClient().newDocumentManager().search(qDef, 1);
@@ -109,8 +71,17 @@ public class ApplyTransformMarkLogicIT extends AbstractMarkLogicIT {
         });
     }
 
-    @AfterEach
-    public void teardown() {
-        deleteDocumentsInCollection(collection);
+    private void loadDocumentsIntoCollection(String collection, List<IngestDoc> documents) {
+        WriteBatcher writeBatcher = dataMovementManager.newWriteBatcher()
+                .withBatchSize(3)
+                .withThreadCount(3);
+        dataMovementManager.startJob(writeBatcher);
+        for (IngestDoc document : documents) {
+            DocumentMetadataHandle handle = new DocumentMetadataHandle();
+            handle.withCollections(collection);
+            writeBatcher.add(document.getFileName(), handle, new StringHandle(document.getContent()));
+        }
+        writeBatcher.flushAndWait();
+        dataMovementManager.stopJob(writeBatcher);
     }
 }

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
@@ -29,6 +29,7 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -56,18 +57,17 @@ public class PutMarkLogicDuplicateUriTest extends AbstractMarkLogicProcessorTest
 		Map<String, String> attributes = new HashMap<>();
 		attributes.put("id", "123456.json");
 
-		MockFlowFile flowFile = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
 		processor.onTrigger(processContext, mockProcessSessionFactory);
-		MockFlowFile flowFile2 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
 		processor.onTrigger(processContext, mockProcessSessionFactory);
-		MockFlowFile flowFile3 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
 
 		processor.onTrigger(processContext, mockProcessSessionFactory);
 
 		assertEquals("Should only be 3 uri in uriFlowFileMap", 3, TestDuplicatePutMarkLogic.uriFlowFileMap.size());
 		assertEquals("Should only be 0 uri in duplicateFlowFileMap", 0,	TestDuplicatePutMarkLogic.duplicateFlowFileMap.size());
 		assertEquals(3, processor.writeEventsCount);
-		processor.onScheduled(processContext);
 	}
 
 	@Test
@@ -84,9 +84,9 @@ public class PutMarkLogicDuplicateUriTest extends AbstractMarkLogicProcessorTest
 
 		MockFlowFile flowFile = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
 		processor.onTrigger(processContext, mockProcessSessionFactory);
-		MockFlowFile flowFile2 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
 		processor.onTrigger(processContext, mockProcessSessionFactory);
-		MockFlowFile flowFile3 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
 
 		processor.onTrigger(processContext, mockProcessSessionFactory);
 
@@ -96,8 +96,8 @@ public class PutMarkLogicDuplicateUriTest extends AbstractMarkLogicProcessorTest
 		assertEquals("The first flowFile UUID should be the currentFlowFileUUID ",
 				flowFile.getAttribute(CoreAttributes.UUID.key()), processor.lastUUID);
 		assertEquals("Should be only 1 writeEvent",1, processor.writeEventsCount);
-		processor.onScheduled(processContext);
 	}
+
 	@Test
 	public void testDuplicateUriUseCloseBatchHandling() {
 		processContext.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.CLOSE_BATCH);
@@ -117,10 +117,8 @@ public class PutMarkLogicDuplicateUriTest extends AbstractMarkLogicProcessorTest
 		attributes.put("index", "3");
 		MockFlowFile flowFile3 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
 		// The last superseded flow file is always the flowFile2
-		String lastFlowUUID = flowFile2.getAttribute(CoreAttributes.UUID.key());
 		processor.onTrigger(processContext, mockProcessSessionFactory);
-		//assertEquals("CloseBatchWriter should be 2",2,processor.closeWriterBatcherCount);
-		//processor.onScheduled(processContext);
+		assertEquals("CloseBatchWriter should be 2",2,processor.closeWriterBatcherCount);
 	}
 }
 

--- a/nifi-marklogic-processors/src/test/ml-modules/transforms/AddAttribute.xsl
+++ b/nifi-marklogic-processors/src/test/ml-modules/transforms/AddAttribute.xsl
@@ -1,0 +1,12 @@
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:map="http://marklogic.com/xdmp/map">
+    <xsl:param name="context" as="map:map"/>
+    <xsl:param name="params"  as="map:map"/>
+    <xsl:template match="/*">
+        <xsl:copy>
+            <xsl:attribute name="{(map:get($params,'name'),'transformed')[1]}" select="(map:get($params,'value'),'UNDEFINED')[1]"/>
+            <xsl:copy-of select="@*"/>
+            <xsl:copy-of select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Added logging to QueryMarkLogic to both help debug the Apply test, and it seems useful in general. 

Moved AddAttribute into a transform that gets deployed via mlDeploy. The test was hanging when installing a transform, writing data, and then running the processor. Does not hang when only writing data and running the processor. 

Removed seemingly useless onScheduled calls in PutMarkLogicDuplicateUriTest that were producing NPEs.