### PR TITLE
#101: PutML now flushes writes when unscheduled

### DIFF
--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicIT.java
@@ -47,7 +47,7 @@ public class PutMarkLogicIT extends AbstractMarkLogicIT{
     }
 
     @Test
-    public void simpleIngest() throws InitializationException {
+    public void simpleIngest() {
         String collection = "PutMarkLogicTest";
         String absolutePath = "/dummyPath/PutMarkLogicTest";
         TestRunner runner = getNewTestRunner(PutMarkLogic.class);
@@ -71,7 +71,7 @@ public class PutMarkLogicIT extends AbstractMarkLogicIT{
     }
 
     @Test
-    public void transformParameters() throws InitializationException, IOException {
+    public void transformParameters() {
         String collection = "transform";
         String transform = "servertransform";
         TestRunner runner = getNewTestRunner(PutMarkLogic.class);


### PR DESCRIPTION
This is thought to be a fix for https://github.com/marklogic-community/marklogic-nifi-incubator/issues/98 , though it's not certain as we don't have reproducible steps for a problem. But supporting OnUnscheduled seems very safe to do. 