### PR TITLE
90 ExtensionCallMarkLogic sends to success when REST call responds 500

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
@@ -129,7 +129,7 @@ public class ApplyTransformMarkLogic extends QueryMarkLogic {
         return applyTransform;
     }
 
-    public static class ApplyResultTypes extends AllowableValuesSet {
+    public static class ApplyResultTypes {
         public static final String INGORE_STR = "Ignore";
         public static final AllowableValue IGNORE = new AllowableValue(INGORE_STR, INGORE_STR,
                 "Run the transform on each document, but ignore the value returned by the transform because the transform " +

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
@@ -301,7 +301,7 @@ public class ExecuteScriptMarkLogic extends AbstractMarkLogicProcessor {
 
             session.commit();
         } catch (final Throwable t) {
-            this.handleThrowable(t, session);
+            this.logErrorAndRollbackSession(t, session);
         }
     }
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
@@ -19,7 +19,6 @@ package org.apache.nifi.marklogic.processor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,13 +26,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.marklogic.client.DatabaseClient;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.SystemResource;
 import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.TriggerWhenEmpty;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
-import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -407,7 +404,7 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
                 }
             }
         } catch (final Throwable t) {
-            this.handleThrowable(t, session);
+            this.logErrorAndRollbackSession(t, session);
         }
     }
     /*

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
@@ -277,7 +277,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
             session.commit();
         } catch (final Throwable t) {
             context.yield();
-            this.handleThrowable(t, session);
+            this.logErrorAndRollbackSession(t, session);
         }
     }
 
@@ -592,7 +592,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
         return handle;
     }
 
-    public static class QueryTypes extends AllowableValuesSet {
+    public static class QueryTypes {
         public static final String COLLECTION_STR = "Collection Query";
         public static final AllowableValue COLLECTION = new AllowableValue(COLLECTION_STR, COLLECTION_STR,
                 "Comma-separated list of collections to query from a MarkLogic server");
@@ -618,7 +618,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
 
     }
 
-    public static class ReturnTypes extends AllowableValuesSet {
+    public static class ReturnTypes {
         public static final String URIS_ONLY_STR = "URIs Only";
         public static final AllowableValue URIS_ONLY = new AllowableValue(URIS_ONLY_STR, URIS_ONLY_STR,
                 "Only return document URIs for matching documents in FlowFile attribute");
@@ -637,7 +637,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
 
     }
 
-    public static class IndexTypes extends AllowableValuesSet {
+    public static class IndexTypes {
         public static final String ELEMENT_STR = "Element Index";
         public static final AllowableValue ELEMENT = new AllowableValue(ELEMENT_STR, ELEMENT_STR,
                 "Index on an element. (Namespaces can be defined with dynamic properties prefixed with 'ns:'.)");

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogic.java
@@ -89,7 +89,7 @@ public class QueryRowsMarkLogic extends AbstractMarkLogicProcessor {
 			
 			transferAndCommit(session, flowFile, SUCCESS);
 		} catch (final Throwable t) {
-			this.handleThrowable(t, session);
+			this.logErrorAndRollbackSession(t, session);
 		}
 	}
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
@@ -161,7 +161,7 @@ public class RunFlowMarkLogic extends AbstractMarkLogicProcessor {
 			session.write(flowFile, out -> out.write(response.toJson().getBytes()));
 			transferAndCommit(session, flowFile, FINISHED);
 		} catch (Throwable t) {
-			this.handleThrowable(t, session);
+			this.logErrorAndRollbackSession(t, session);
 		}
 	}
 

--- a/nifi-marklogic-processors/src/test/ml-modules/services/throwsError.xqy
+++ b/nifi-marklogic-processors/src/test/ml-modules/services/throwsError.xqy
@@ -1,0 +1,11 @@
+xquery version "1.0-ml";
+
+module namespace resource = "http://marklogic.com/rest-api/resource/throwsError";
+
+declare function get(
+        $context as map:map,
+        $params as map:map
+) as document-node()*
+{
+    fn:error(xs:QName("GetErrorQName"), "GetError Description", (500, "GetError message"))
+};


### PR DESCRIPTION
In addition, "markLogicErrorMessage" is added as an attribute to the flowfile. 

Also removed AllowableValuesSet class, which had a field that wasn't being used anywhere, and thus the class wasn't doing anything. 

I am thinking that a follow-up ticket will change the other processes that rollback the session to instead route the failed FF to a "failure" relationship with the error message as a new attribute. That seems like a better UX, as it gives the flow developer a way to figure out what to do with the FF. 