### PR TITLE
73 NullPointerException on ExtensionCallMarklogic for PUT and DELETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ for information on obtaining the connector, installing it, and using it.
 ## Building and testing the connector
 
 If you'd like to build the MarkLogic NiFi connector from source, you'll first need to 
-[download and install Apache Maven](https://maven.apache.org/) if you do not already have it installed. Then, clone
-this repository locally and run the following command to build the two NAR files:
+[download and install Apache Maven](https://maven.apache.org/) if you do not already have it installed. Additionally, 
+you should use Java 8, which NiFi 1.9.x requires. 
+
+Then, clone this repository locally and run the following command to build the two NAR files:
 
     mvn clean install -DskipTests
 
@@ -40,7 +42,7 @@ developing the connector - please use an IDE such as IntelliJ that is able to ru
 at the same time.
 
 After cloning this repository locally and installing Maven, you can run the tests for the connector by performing the 
-following steps:
+following steps (as noted above, be sure to use Java 8):
 
 1. cd nifi-marklogic-processors
 1. Put your ML admin username/password in gradle-local.properties (a gitignored file, so you'll need to create it)

--- a/nifi-marklogic-processors/gradle/wrapper/gradle-wrapper.properties
+++ b/nifi-marklogic-processors/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
@@ -121,4 +121,60 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         assertTrue(message.contains("Server Message: GetError Description (GetErrorQName): 500 GetError message"),
                 "The error message should contain the error details from the REST extension");
     }
+
+    @Test
+    void getEmptyPayload() {
+        TestRunner runner = newEmptyEndpointsTestRunner(ExtensionCallMarkLogic.MethodTypes.GET_STR);
+        runWithSingleEmptyFlowFile(runner);
+        assertEquals(1, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size());
+    }
+
+    @Test
+    void putEmptyPayload() {
+        TestRunner runner = newEmptyEndpointsTestRunner(ExtensionCallMarkLogic.MethodTypes.PUT_STR);
+        runWithSingleEmptyFlowFile(runner);
+        assertEquals(1, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size());
+    }
+
+    @Test
+    void putPayloadWithEmptyByteArray() {
+        TestRunner runner = newEmptyEndpointsTestRunner(ExtensionCallMarkLogic.MethodTypes.PUT_STR);
+
+        runner.enqueue(new byte[]{});
+        runner.run(1);
+        runner.assertQueueEmpty();
+
+        assertEquals(1, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size(),
+                "Verifies that an empty byte array is fine; the Java Client only complains if the byte array is null");
+    }
+
+    @Test
+    void postEmptyPayload() {
+        TestRunner runner = newEmptyEndpointsTestRunner(ExtensionCallMarkLogic.MethodTypes.POST_STR);
+        runWithSingleEmptyFlowFile(runner);
+        assertEquals(1, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size());
+    }
+
+    @Test
+    void deleteEmptyPayload() {
+        TestRunner runner = newEmptyEndpointsTestRunner(ExtensionCallMarkLogic.MethodTypes.DELETE_STR);
+        runWithSingleEmptyFlowFile(runner);
+        assertEquals(1, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size());
+    }
+
+    private TestRunner newEmptyEndpointsTestRunner(String methodType) {
+        TestRunner runner = getNewTestRunner(ExtensionCallMarkLogic.class);
+        runner.setValidateExpressionUsage(false);
+        runner.setProperty(ExtensionCallMarkLogic.EXTENSION_NAME, "emptyEndpoints");
+        runner.setProperty(ExtensionCallMarkLogic.METHOD_TYPE, methodType);
+        runner.setProperty(ExtensionCallMarkLogic.REQUIRES_INPUT, "true");
+        runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_SOURCE, ExtensionCallMarkLogic.PayloadSources.NONE);
+        return runner;
+    }
+
+    private void runWithSingleEmptyFlowFile(TestRunner runner) {
+        runner.enqueue(new MockFlowFile(1));
+        runner.run(1);
+        runner.assertQueueEmpty();
+    }
 }

--- a/nifi-marklogic-processors/src/test/ml-modules/services/emptyEndpoints.xqy
+++ b/nifi-marklogic-processors/src/test/ml-modules/services/emptyEndpoints.xqy
@@ -1,0 +1,37 @@
+xquery version "1.0-ml";
+
+module namespace resource = "http://marklogic.com/rest-api/resource/emptyEndpoints";
+
+declare function get(
+  $context as map:map,
+  $params  as map:map
+  ) as document-node()*
+{
+  xdmp:log(("GET called", $context, $params))
+};
+
+declare function put(
+  $context as map:map,
+  $params  as map:map,
+  $input   as document-node()*
+  ) as document-node()?
+{
+  xdmp:log(("PUT called", $input, $context, $params))
+};
+
+declare function post(
+  $context as map:map,
+  $params  as map:map,
+  $input   as document-node()*
+  ) as document-node()*
+{
+  xdmp:log(("POST called", $input, $context, $params))
+};
+
+declare function delete(
+  $context as map:map,
+  $params  as map:map
+  ) as document-node()?
+{
+  xdmp:log(("DELETE called", $context, $params))
+};


### PR DESCRIPTION
Did some cleanup of logError to ensure the stacktrace shows up. 

ExtensionCallML now only sets the request body to an empty byte array for a PUT request, since that's the only one that fails with a null input. 