### PR TITLE
Adding an option to set document quality as part of PutMarklogic

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
@@ -106,6 +106,15 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         .addValidator(Validator.VALID)
         .build();
 
+    public static final PropertyDescriptor QUALITY = new PropertyDescriptor.Builder()
+        .name("Quality")
+        .displayName("Quality")
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .description("Quality for each document; if not specified, MarkLogic will set default quality 0")
+        .required(false)
+        .addValidator(StandardValidators.INTEGER_VALIDATOR)
+        .build();
+
     public static final PropertyDescriptor FORMAT = new PropertyDescriptor.Builder()
         .name("Format")
         .displayName("Format")
@@ -228,6 +237,7 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         List<PropertyDescriptor> list = new ArrayList<>();
         list.addAll(properties);
         list.add(COLLECTIONS);
+        list.add(QUALITY);
         list.add(FORMAT);
         list.add(JOB_ID);
         list.add(JOB_NAME);
@@ -462,6 +472,12 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         final String permissionsValue = permissionsProperty.isSet() ?
             permissionsProperty.evaluateAttributeExpressions(flowFile).getValue() : null;
         final String[] tokens = getArrayFromCommaSeparatedString(permissionsValue);
+
+        Integer quality = context.getProperty(QUALITY).evaluateAttributeExpressions(flowFile).asInteger();
+        if (quality != null) {
+            metadata.withQuality(quality);
+        }
+        
         if (tokens != null) {
             DocumentMetadataHandle.DocumentPermissions permissions = metadata.getPermissions();
             for (int i = 0; i < tokens.length; i += 2) {

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicTest.java
@@ -377,6 +377,44 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
         assertEquals("FlowFile metadata keys are specific to a document/FlowFile",
                 ExpressionLanguageScope.FLOWFILE_ATTRIBUTES, descriptor.getExpressionLanguageScope());
     }
+
+    @Test
+    public void checkDefaultQuality() {
+        processor.initialize(initializationContext);
+        // Sample Random File
+        addFlowFile("<test/>");
+
+        processor.onTrigger(processContext, mockProcessSessionFactory);
+
+        DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
+        assertEquals(0, metadata.getQuality());
+    }
+
+    @Test
+    public void setQuality() {
+        processContext.setProperty(PutMarkLogic.QUALITY, "10");
+        processor.initialize(initializationContext);
+        // Sample Random File
+        addFlowFile("<test/>");
+
+        processor.onTrigger(processContext, mockProcessSessionFactory);
+
+        DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
+        assertEquals(10, metadata.getQuality());
+    }
+
+    @Test
+    public void setNegativeQuality() {
+        processContext.setProperty(PutMarkLogic.QUALITY, "-10");
+        processor.initialize(initializationContext);
+        // Sample Random File
+        addFlowFile("<test/>");
+
+        processor.onTrigger(processContext, mockProcessSessionFactory);
+
+        DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
+        assertEquals(-10, metadata.getQuality());
+    }
 }
 
 /**


### PR DESCRIPTION
Thank you for submitting a contribution to marklogic-community/marklogic-nifi-incubator.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [#120 ] Is there a github ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [x] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?