### PR TITLE
Upgrading to NiFi 1.15.3 to deal with log4j and SSL security vulnerabilities

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -16,9 +16,9 @@ Please direct questions, comments and requests regarding this notice or other li
 To the extent required by the applicable open source license, a complete machine-readable copy of the source code corresponding to such code is available upon request. This offer is valid to anyone in receipt of this information and shall expire three years following the date of the final distribution of this product version by MarkLogic. To obtain such source code, send an email to legal@marklogic.com. Please specify the product and version for which you are requesting source code.
 
 
-The following software may be included in this project (last updated January 26, 2021):
+The following software may be included in this project (last updated April 6, 2022):
 
-Apache NiFi 1.9.1
+Apache NiFi 1.15.3
 Attribution Statements
 http://nifi.apache.org/
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,6 @@
 ﻿MarkLogic® NiFi
 
-Copyright © 2021 MarkLogic Corporation.
+Copyright © 2022 MarkLogic Corporation.
 
 This project is licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The MarkLogic NiFi connector simplifies integrating [Apache NiFi](https://nifi.apache.org/) with MarkLogic, allowing for 
 data to be easily written to and read from MarkLogic. The connector consists of a set of custom NiFi processors and 
 controller services which can be used in NiFi flows for integrating with MarkLogic. The connector has been developed 
-and tested on NiFi 1.9.1; it may work in more recent versions of NiFi too. 
+and tested on NiFi 1.15.3; it may work in more recent versions of NiFi too. 
 
 Please see the [Getting Started guide](https://marklogic-community.github.io/marklogic-nifi-incubator/getting-started.html) 
 for information on obtaining the connector, installing it, and using it. 
@@ -13,7 +13,7 @@ for information on obtaining the connector, installing it, and using it.
 
 If you'd like to build the MarkLogic NiFi connector from source, you'll first need to 
 [download and install Apache Maven](https://maven.apache.org/) if you do not already have it installed. Additionally, 
-you should use Java 8, which NiFi 1.9.x requires. 
+you should use Java 8, which NiFi 1.15.x requires. 
 
 Then, clone this repository locally and run the following command to build the two NAR files:
 
@@ -54,7 +54,7 @@ You should have output like this:
 
 ```
 [INFO] ------------------------------------------------------------------------
-[INFO] Reactor Summary for nifi-marklogic-bundle 1.9.1.6:
+[INFO] Reactor Summary for nifi-marklogic-bundle 1.15.3:
 [INFO] 
 [INFO] nifi-marklogic-bundle .............................. SUCCESS [  1.062 s]
 [INFO] nifi-marklogic-services-api ........................ SUCCESS [  1.032 s]

--- a/nifi-marklogic-nar/pom.xml
+++ b/nifi-marklogic-nar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.9.1.7</version>
+        <version>1.15.3</version>
     </parent>
 
     <artifactId>nifi-marklogic-nar</artifactId>

--- a/nifi-marklogic-processors/pom.xml
+++ b/nifi-marklogic-processors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.9.1.7</version>
+        <version>1.15.3</version>
     </parent>
 
     <artifactId>nifi-marklogic-processors</artifactId>
@@ -39,11 +39,11 @@
     </repositories>
 
     <dependencies>
-		<dependency>
-		    <groupId>org.json</groupId>
-		    <artifactId>json</artifactId>
-		    <version>20180130</version>
-		</dependency>
+<!--		<dependency>-->
+<!--		    <groupId>org.json</groupId>-->
+<!--		    <artifactId>json</artifactId>-->
+<!--		    <version>20180130</version>-->
+<!--		</dependency>-->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
@@ -71,6 +71,10 @@
                 <exclusion>
                     <groupId>com.beust</groupId>
                     <artifactId>jcommander</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -195,6 +199,20 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.30</version>
             <scope>test</scope>
+        </dependency>
+
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.2</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.2</version>
         </dependency>
     </dependencies>
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
@@ -246,7 +246,7 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
     protected void transferAndCommit(ProcessSession session, FlowFile flowFile, Relationship relationship) {
         synchronized (session) {
             session.transfer(flowFile, relationship);
-            session.commit();
+            session.commitAsync();
         }
     }
 }

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
@@ -111,7 +111,7 @@ public class ApplyTransformMarkLogic extends QueryMarkLogic {
                         session.putAttribute(flowFile, CoreAttributes.FILENAME.key(), uri);
                         session.transfer(flowFile, SUCCESS);
                     }
-                    session.commit();
+                    session.commitAsync();
                 }
             })
             .onFailure((batch, throwable) -> {
@@ -122,7 +122,7 @@ public class ApplyTransformMarkLogic extends QueryMarkLogic {
                         session.putAttribute(flowFile, CoreAttributes.FILENAME.key(), uri);
                         session.transfer(flowFile, FAILURE);
                     }
-                    session.commit();
+                    session.commitAsync();
                 }
                 context.yield();
             });

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/DeleteMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/DeleteMarkLogic.java
@@ -96,7 +96,7 @@ public class DeleteMarkLogic extends QueryMarkLogic {
                     session.putAttribute(flowFile, CoreAttributes.FILENAME.key(), uri);
                     session.transfer(flowFile, FAILURE);
                 }
-                session.commit();
+                session.commitAsync();
                 context.yield();
             }
         });
@@ -119,7 +119,7 @@ public class DeleteMarkLogic extends QueryMarkLogic {
                     session.putAttribute(flowFile, CoreAttributes.FILENAME.key(), uri);
                     session.transfer(flowFile, SUCCESS);
                 }
-                session.commit();
+                session.commitAsync();
             }
         }
     }

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
@@ -299,7 +299,7 @@ public class ExecuteScriptMarkLogic extends AbstractMarkLogicProcessor {
                 session.transfer(lastFF, LAST_RESULT);
             }
 
-            session.commit();
+            session.commitAsync();
         } catch (final Throwable t) {
             this.logErrorAndRollbackSession(t, session);
         }

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
@@ -224,7 +224,7 @@ public class PutMarkLogicRecord extends PutMarkLogic {
                 getLogger().info("Inserted {} records into MarkLogic", new Object[]{ added });
             }
         }
-        session.commit();
+        session.commitAsync();
     }
 
     @Override

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
@@ -274,7 +274,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
             getLogger().info("Stopping job");
             dataMovementManager.stopJob(queryBatcher);
             getLogger().info("Committing session");
-            session.commit();
+            session.commitAsync();
         } catch (final Throwable t) {
             context.yield();
             this.logErrorAndRollbackSession(t, session);
@@ -408,7 +408,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
                                 getLogger().debug("Routing " + uri + " to " + SUCCESS.getName());
                             }
                         });
-                        session.commit();
+                        session.commitAsync();
                     }
                 }
             };
@@ -548,7 +548,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
             getLogger().error("Query failure: " + exception.getMessage());
             FlowFile failureFlowFile = incomingFlowFile != null ? session.penalize(incomingFlowFile) : session.create();
             session.transfer(failureFlowFile, FAILURE);
-            session.commit();
+            session.commitAsync();
             context.yield();
         });
         return queryBatcher;

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecordTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecordTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.marklogic.processor;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,8 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.marklogic.processor.ExecuteScriptMarkLogicTest.TestExecuteScriptMarkLogic;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
 import org.apache.nifi.serialization.SimpleRecordSchema;
@@ -182,14 +185,19 @@ class TestRecordReaderFactory extends AbstractControllerService implements Recor
 
     public TestRecordReader testRecordReader = new TestRecordReader();
 
-    @Override
-    public RecordReader createRecordReader(Map<String, String> map, InputStream inputStream, ComponentLog componentLog) {
-        return testRecordReader;
-    }
+//    @Override
+//    public RecordReader createRecordReader(Map<String, String> map, InputStream inputStream, ComponentLog componentLog) {
+//        return testRecordReader;
+//    }
 
     @Override
     public RecordReader createRecordReader(FlowFile flowFile, InputStream in, ComponentLog logger) {
         return testRecordReader;
+    }
+
+    @Override
+    public RecordReader createRecordReader(Map<String, String> map, InputStream inputStream, long l, ComponentLog componentLog) throws MalformedRecordException, IOException, SchemaNotFoundException {
+        return null;
     }
 }
 

--- a/nifi-marklogic-services-api-nar/pom.xml
+++ b/nifi-marklogic-services-api-nar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.9.1.7</version>
+        <version>1.15.3</version>
     </parent>
 
     <artifactId>nifi-marklogic-services-api-nar</artifactId>

--- a/nifi-marklogic-services-api/pom.xml
+++ b/nifi-marklogic-services-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.9.1.7</version>
+        <version>1.15.3</version>
     </parent>
 
     <artifactId>nifi-marklogic-services-api</artifactId>

--- a/nifi-marklogic-services-nar/pom.xml
+++ b/nifi-marklogic-services-nar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.9.1.7</version>
+        <version>1.15.3</version>
     </parent>
 
     <artifactId>nifi-marklogic-services-nar</artifactId>

--- a/nifi-marklogic-services/pom.xml
+++ b/nifi-marklogic-services/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.9.1.7</version>
+        <version>1.15.3</version>
     </parent>
 
     <artifactId>nifi-marklogic-services</artifactId>

--- a/nifi-marklogic-services/src/main/java/org/apache/nifi/marklogic/controller/DefaultMarkLogicDatabaseClientService.java
+++ b/nifi-marklogic-services/src/main/java/org/apache/nifi/marklogic/controller/DefaultMarkLogicDatabaseClientService.java
@@ -203,10 +203,15 @@ public class DefaultMarkLogicDatabaseClientService extends AbstractControllerSer
             try {
                 if (sslService.isTrustStoreConfigured()) {
                     final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-                    final KeyStore trustStore = KeyStoreUtils.getTrustStore(sslService.getTrustStoreType());
-                    try (final InputStream is = new FileInputStream(sslService.getTrustStoreFile())) {
-                        trustStore.load(is, sslService.getTrustStorePassword().toCharArray());
-                    }
+//                    final KeyStore trustStore = KeyStoreUtils.getTrustStore(sslService.getTrustStoreType());
+//                    try (final InputStream is = new FileInputStream(sslService.getTrustStoreFile())) {
+//                        trustStore.load(is, );
+//                    }
+                    final KeyStore trustStore = KeyStoreUtils.loadTrustStore(
+                            sslService.getTrustStoreFile(),
+                            sslService.getTrustStorePassword().toCharArray(),
+                            sslService.getTrustStoreType()
+                    );
                     trustManagerFactory.init(trustStore);
                     config.setTrustManager((X509TrustManager) trustManagerFactory.getTrustManagers()[0]);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,18 +21,18 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>1.9.1</version>
+        <version>1.15.3</version>
     </parent>
 
 
-    <version>1.9.1.7</version>
+    <version>1.15.3</version>
 
     <artifactId>nifi-marklogic-bundle</artifactId>
     <packaging>pom</packaging>
 
     <properties>
-        <nifi.version>1.9.1</nifi.version>
-        <marklogicnar.version>1.9.1.7</marklogicnar.version>
+        <nifi.version>1.15.3</nifi.version>
+        <marklogicnar.version>1.15.3</marklogicnar.version>
         <marklogicclientapi.version>5.3.2</marklogicclientapi.version>
         <mljavaclientutil.version>4.1.1</mljavaclientutil.version>
         <marklogicdatamovementcomponents.version>2.2.1</marklogicdatamovementcomponents.version>


### PR DESCRIPTION
This work was performed for a support ticket: https://help.marklogic.com/staff/Tickets/Ticket/View/33812

- Upgraded the POM files to use NiFi 1.15.3 and changed the artifact versions to 1.15.3
- Updated TrustStore creation since org.apache.nifi.security.util.KeyStoreUtils 1.13.0 changed the way TrustStores are generated.
- Excluding commons-logging since NiFi 1.15.2 began enforcing the exclusion of commons-logging
- Excluding org.json since NiFi 1.12.0 began excluding org.json.
-- Removed org.json:json dependency from the nifi-marklogic-processors POM file and changed the code to use gson instead. 
- Added two dependencies to the nifi-marklogic-processors POM file to get the tests to pass
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- NiFi 1.15.3 is complaining about session.commit(), so I replaced with commitAsync()