### PR TITLE
Bumping dependencies and version to 1.16.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ at the same time.
 After cloning this repository locally and installing Maven, you can run the tests for the connector by performing the 
 following steps (as noted above, be sure to use Java 8):
 
-1. cd nifi-marklogic-processors
+1. `cd nifi-marklogic-processors`
 1. Put your ML admin username/password in gradle-local.properties (a gitignored file, so you'll need to create it)
-1. Run ./gradlew -i mldeploy (uses Gradle to deploy a small test application to ML)
-1. cd ..
-1. Run "mvn clean test"
+1. Run `./gradlew -i mldeploy` (uses Gradle to deploy a small test application to ML)
+1. `cd ..`
+1. Run `mvn clean test`
 
 You should have output like this:
 

--- a/nifi-marklogic-nar/pom.xml
+++ b/nifi-marklogic-nar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.15.3.2</version>
+        <version>1.16.3.1</version>
     </parent>
 
     <artifactId>nifi-marklogic-nar</artifactId>

--- a/nifi-marklogic-processors/build.gradle
+++ b/nifi-marklogic-processors/build.gradle
@@ -3,6 +3,6 @@
  * run against.
  */
 plugins {
-	id 'net.saliman.properties' version '1.5.1'
-	id 'com.marklogic.ml-gradle' version '4.3.4'
+	id 'net.saliman.properties' version '1.5.2'
+	id 'com.marklogic.ml-gradle' version '4.3.5'
 }

--- a/nifi-marklogic-processors/pom.xml
+++ b/nifi-marklogic-processors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.15.3.2</version>
+        <version>1.16.3.1</version>
     </parent>
 
     <artifactId>nifi-marklogic-processors</artifactId>
@@ -32,56 +32,30 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
     </repositories>
 
     <dependencies>
-<!--		<dependency>-->
-<!--		    <groupId>org.json</groupId>-->
-<!--		    <artifactId>json</artifactId>-->
-<!--		    <version>20180130</version>-->
-<!--		</dependency>-->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
             <version>${nifi.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-processor-utils</artifactId>
-            <version>${nifi.version}</version>
-        </dependency>
+
+        <!-- Force usage of this version until DHF 5.8 is available -->
         <dependency>
             <groupId>com.marklogic</groupId>
-            <artifactId>marklogic-data-hub</artifactId>
-            <version>5.4.4</version>
-            <!-- Excluding DH stuff we don't need -->
-            <exclusions>
-                <exclusion>
-                    <groupId>com.marklogic</groupId>
-                    <artifactId>mlcp-util</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.marklogic</groupId>
-                    <artifactId>marklogic-data-movement-components</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.beust</groupId>
-                    <artifactId>jcommander</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>ml-app-deployer</artifactId>
+            <version>4.3.4</version>
         </dependency>
         <dependency>
             <groupId>com.marklogic</groupId>
             <artifactId>marklogic-client-api</artifactId>
             <version>${marklogicclientapi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.marklogic</groupId>
+            <artifactId>marklogic-data-hub</artifactId>
+            <version>5.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -94,14 +68,16 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.9.1</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-marklogic-services-api</artifactId>
             <version>${marklogicnar.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
@@ -145,68 +121,32 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.8.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>5.3.18</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.marklogic</groupId>
             <artifactId>marklogic-junit5</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.1</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-test</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Forcing Spring to use logback -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
             <scope>test</scope>
         </dependency>
 
-
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.13.2</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.13.2</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogic.java
@@ -5,7 +5,6 @@ import com.marklogic.client.expression.PlanBuilder;
 import com.marklogic.client.io.InputStreamHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.row.RowManager;
-import org.apache.commons.io.IOUtils;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -15,6 +14,7 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.*;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.springframework.util.FileCopyUtils;
 
 import java.io.InputStream;
 import java.util.*;
@@ -84,7 +84,7 @@ public class QueryRowsMarkLogic extends AbstractMarkLogicProcessor {
 			if (inputStream != null) {
 				try {
 					flowFile = session.write(flowFile, out -> {
-						IOUtils.copy(inputStream, out);
+						FileCopyUtils.copy(inputStream, out);
 					});
 				} finally {
 					inputStream.close();

--- a/nifi-marklogic-services-api-nar/pom.xml
+++ b/nifi-marklogic-services-api-nar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.15.3.2</version>
+        <version>1.16.3.1</version>
     </parent>
 
     <artifactId>nifi-marklogic-services-api-nar</artifactId>

--- a/nifi-marklogic-services-api/pom.xml
+++ b/nifi-marklogic-services-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.15.3.2</version>
+        <version>1.16.3.1</version>
     </parent>
 
     <artifactId>nifi-marklogic-services-api</artifactId>
@@ -44,17 +44,7 @@
         <dependency>
             <groupId>com.marklogic</groupId>
             <artifactId>ml-javaclient-util</artifactId>
-            <version>${mljavaclientutil.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.marklogic</groupId>
-                    <artifactId>marklogic-xcc</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jdom</groupId>
-                    <artifactId>jdom2</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>4.3.3</version>
         </dependency>
     </dependencies>
 

--- a/nifi-marklogic-services-nar/pom.xml
+++ b/nifi-marklogic-services-nar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.15.3.2</version>
+        <version>1.16.3.1</version>
     </parent>
 
     <artifactId>nifi-marklogic-services-nar</artifactId>

--- a/nifi-marklogic-services/pom.xml
+++ b/nifi-marklogic-services/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-marklogic-bundle</artifactId>
-        <version>1.15.3.2</version>
+        <version>1.16.3.1</version>
     </parent>
 
     <artifactId>nifi-marklogic-services</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,10 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>1.15.3</version>
+        <version>1.16.3</version>
     </parent>
 
-
-    <version>1.15.3.2</version>
+    <version>1.16.3.1</version>
 
     <artifactId>nifi-marklogic-bundle</artifactId>
     <packaging>pom</packaging>
@@ -33,12 +32,9 @@
     <properties>
         <!-- Ensure that the NARs will work on Java 8, as NiFi requires either Java 8 or 11 -->
         <maven.compiler.release>8</maven.compiler.release>
-        <nifi.version>1.15.3</nifi.version>
-        <marklogicnar.version>1.15.3.2</marklogicnar.version>
-        <!-- MarkLogic Client 5.5.0 is required for DHF 5.4.x projects to continue to work -->
-        <marklogicclientapi.version>5.5.0</marklogicclientapi.version>
-        <mljavaclientutil.version>4.3.1</mljavaclientutil.version>
-        <marklogicdatamovementcomponents.version>2.4.0</marklogicdatamovementcomponents.version>
+        <nifi.version>1.16.3</nifi.version>
+        <marklogicnar.version>1.16.3.1</marklogicnar.version>
+        <marklogicclientapi.version>5.5.3</marklogicclientapi.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Made one small change to QueryRowsMarkLogic to use FileCopyUtils instead of IOUtils for the same job - the former is on the compile classpath, the latter is not. 

Also, removed the dependencies forcing usage of 2.13.x Jackson. The ML Java Client is still on 2.12.x. 