### PR TITLE
RunFlowMarkLogic now uses trust manager from the controller service

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.client.ext.DatabaseClientConfig;
+import com.marklogic.client.ext.modulesloader.ssl.SimpleX509TrustManager;
 import com.marklogic.hub.DatabaseKind;
 import com.marklogic.hub.flow.FlowInputs;
 import com.marklogic.hub.flow.FlowRunner;
@@ -25,6 +26,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StringUtils;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.util.*;
 
@@ -191,6 +193,15 @@ public class RunFlowMarkLogic extends AbstractMarkLogicProcessor {
 				hubConfig.setSslHostnameVerifier(DatabaseKind.FINAL, verifier);
 				hubConfig.setSslHostnameVerifier(DatabaseKind.JOB, verifier);
 			}
+
+			X509TrustManager trustManager = clientConfig.getTrustManager();
+			if (trustManager == null) {
+				getLogger().info("No X509TrustManager found; using 'trust everything' X509TrustManager implementation");
+				trustManager = new SimpleX509TrustManager();
+			}
+			hubConfig.setTrustManager(DatabaseKind.STAGING, trustManager);
+			hubConfig.setTrustManager(DatabaseKind.FINAL, trustManager);
+			hubConfig.setTrustManager(DatabaseKind.JOB, trustManager);
 		}
 
 		String externalName = clientConfig.getExternalName();

--- a/nifi-marklogic-services/src/test/java/org/apache/nifi/marklogic/controller/EvaluateExpressionsTest.java
+++ b/nifi-marklogic-services/src/test/java/org/apache/nifi/marklogic/controller/EvaluateExpressionsTest.java
@@ -5,6 +5,7 @@ import com.marklogic.client.ext.SecurityContextType;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.registry.VariableDescriptor;
+import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.MockConfigurationContext;
 import org.apache.nifi.util.MockVariableRegistry;
@@ -99,9 +100,9 @@ public class EvaluateExpressionsTest extends Assert {
 	@Test
 	public void evaluateClientAuth() {
 		verifyScope(DefaultMarkLogicDatabaseClientService.CLIENT_AUTH);
-		variableRegistry.setVariable(new VariableDescriptor("myValue"), SSLContextService.ClientAuth.WANT.name());
+		variableRegistry.setVariable(new VariableDescriptor("myValue"), "WANT");
 		properties.put(DefaultMarkLogicDatabaseClientService.CLIENT_AUTH, "${myValue}");
-		assertEquals(SSLContextService.ClientAuth.WANT, service.determineClientAuth(context));
+		assertEquals(ClientAuth.WANT, service.determineClientAuth(context));
 	}
 
 	private void verifyScope(PropertyDescriptor descriptor) {


### PR DESCRIPTION
Resolves #145 . This was an oversight when the controller was first implemented. 

Also addressed a deprecation; now using the public ClientAuth class. 