### PR TITLE
ExecuteScriptML now routes failures to relationship

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
@@ -215,6 +215,24 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
         throw new ProcessException(t);
     }
 
+    /**
+     * Use this for transferring the FlowFile to a Relationship while both logging the error and capturing its
+     * message in the FlowFile. This allows the user to do whatever they'd like with the FlowFile after a failure
+     * occurs - i.e. they can send it back to the processor for retry, discard it, etc.
+     *
+     * @param t
+     * @param flowFile
+     * @param session
+     * @param relationship
+     */
+    protected void logErrorAndTransfer(Throwable t, FlowFile flowFile, ProcessSession session, Relationship relationship) {
+        logError(t);
+        if (t.getMessage() != null) {
+            session.putAttribute(flowFile, "markLogicErrorMessage", t.getMessage());
+        }
+        transferAndCommit(session, flowFile, relationship);
+    }
+
     protected void logError(Throwable t) {
         final String errorMessage = t.getMessage() != null ? t.getMessage() : "";
         if (t instanceof UnauthorizedUserException || errorMessage.matches(unauthorizedPattern.pattern())) {

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
@@ -169,11 +169,7 @@ public class ExtensionCallMarkLogic extends AbstractMarkLogicProcessor {
             ServiceResultIterator results = callExtension(context, session, originalFlowFile);
             handleExtensionCallResults(results, session, originalFlowFile);
         } catch (Throwable t) {
-            logError(t);
-            if (t.getMessage() != null) {
-                session.putAttribute(originalFlowFile, "markLogicErrorMessage", t.getMessage());
-            }
-            transferAndCommit(session, originalFlowFile, FAILURE);
+            logErrorAndTransfer(t, originalFlowFile, session, FAILURE);
         }
     }
 

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogicIT.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.marklogic.processor;
+
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExecuteScriptMarkLogicIT extends AbstractMarkLogicIT {
+
+    @BeforeEach
+    public void beforeEach() {
+        super.setup();
+    }
+
+    @Test
+    public void validJavascript() {
+        TestRunner runner = super.getNewTestRunner(ExecuteScriptMarkLogic.class);
+        runner.setValidateExpressionUsage(false);
+        runner.setProperty(ExecuteScriptMarkLogic.EXECUTION_TYPE, ExecuteScriptMarkLogic.AV_JAVASCRIPT);
+        runner.setProperty(ExecuteScriptMarkLogic.RESULTS_DESTINATION, ExecuteScriptMarkLogic.AV_CONTENT);
+        runner.setProperty(ExecuteScriptMarkLogic.SCRIPT_BODY, "1 + 1");
+
+        runner.enqueue(new MockFlowFile(3));
+        runner.run(1);
+
+        runner.assertQueueEmpty();
+        assertEquals(0, runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.FAILURE).size());
+
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.RESULTS);
+        assertEquals(1, results.size());
+
+        MockFlowFile result = results.get(0);
+        String resultValue = new String(runner.getContentAsByteArray(result));
+        assertEquals("2", resultValue, "The script is expected to return the value 2");
+    }
+
+    @Test
+    public void invalidJavascript() {
+        TestRunner runner = super.getNewTestRunner(ExecuteScriptMarkLogic.class);
+        runner.setValidateExpressionUsage(false);
+        runner.setProperty(ExecuteScriptMarkLogic.EXECUTION_TYPE, ExecuteScriptMarkLogic.AV_JAVASCRIPT);
+        runner.setProperty(ExecuteScriptMarkLogic.RESULTS_DESTINATION, ExecuteScriptMarkLogic.AV_CONTENT);
+        runner.setProperty(ExecuteScriptMarkLogic.SCRIPT_BODY, "const foo = {}; foo.bar.stuff");
+
+        MockFlowFile mockFlowFile = new MockFlowFile(3);
+        Map<String, String> attributes = new HashMap<>();
+        mockFlowFile.putAttributes(attributes);
+
+        runner.enqueue(mockFlowFile);
+        runner.run(1);
+
+        runner.assertQueueEmpty();
+        assertEquals(0, runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.RESULTS).size());
+
+        List<MockFlowFile> failures = runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.FAILURE);
+        assertEquals(1, failures.size());
+
+        MockFlowFile flowFile = failures.get(0);
+        String error = flowFile.getAttribute("markLogicErrorMessage");
+        assertTrue(error.contains("Error running JavaScript request"), "Unexpected error: " + error);
+    }
+}


### PR DESCRIPTION
Resolves #125 

- Improved descriptions of each relationship
- Extracted buildCall for better readability
- Extracted logErrorAndTransfer