### PR TITLE
Refactored QueryMarkLogic for readability

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
@@ -74,7 +74,7 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
         .required(false)
         .build();
 
-    protected final Map<String, List<PropertyDescriptor>> propertiesByPrefix = new ConcurrentHashMap<String, List<PropertyDescriptor>>();
+    protected final Map<String, List<PropertyDescriptor>> propertiesByPrefix = new ConcurrentHashMap<>();
 
     // Patterns for more friendly error messages.
     private Pattern unauthorizedPattern =
@@ -97,7 +97,15 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
         properties = Collections.unmodifiableList(list);
     }
 
-    public void populatePropertiesByPrefix(ProcessContext context) {
+    /**
+     * Populates the {@code propertiesByPrefix} map based on all the properties in the given context that have a
+     * colon in their name. The text to the left of the colon is treated as a prefix, and every property starting with
+     * that prefix is tossed into a list in the {@code propertiesByPrefix} map. Subclasses can then easily find all
+     * properties that start with a particular (and usually known) prefix.
+     *
+     * @param context
+     */
+    protected void populatePropertiesByPrefix(ProcessContext context) {
         propertiesByPrefix.clear();
         for (PropertyDescriptor propertyDesc : context.getProperties().keySet()) {
             if (propertyDesc.isDynamic() && propertyDesc.getName().contains(":")) {
@@ -105,7 +113,7 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
                 String prefix = parts[0];
                 List<PropertyDescriptor> propertyDescriptors = propertiesByPrefix.get(prefix);
                 if (propertyDescriptors == null) {
-                    propertyDescriptors = new CopyOnWriteArrayList<PropertyDescriptor>();
+                    propertyDescriptors = new CopyOnWriteArrayList<>();
                     propertiesByPrefix.put(prefix, propertyDescriptors);
                 }
                 propertyDescriptors.add(propertyDesc);

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
@@ -87,8 +87,15 @@ public class ApplyTransformMarkLogic extends QueryMarkLogic {
         relationships = Collections.unmodifiableSet(set);
     }
 
+    /**
+     * Overrides the behavior in the parent class for how each batch of URIs should be processed.
+     *
+     * @param context
+     * @param session
+     * @return
+     */
     @Override
-    protected QueryBatchListener buildQueryBatchListener(final ProcessContext context, final ProcessSession session, final boolean consistentSnapshot) {
+    protected QueryBatchListener buildQueryBatchListener(final ProcessContext context, final ProcessSession session) {
         ApplyTransformListener applyTransform = new ApplyTransformListener()
             .withApplyResult(
                 ApplyResultTypes.INGORE_STR.equals(context.getProperty(APPLY_RESULT_TYPE).getValue()) ? ApplyResult.IGNORE : ApplyResult.REPLACE

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/DeleteMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/DeleteMarkLogic.java
@@ -73,8 +73,15 @@ public class DeleteMarkLogic extends QueryMarkLogic {
         super.onTrigger(context, sessionFactory);
     }
 
+    /**
+     * Overrides the behavior in the parent class for how each batch of URIs should be processed.
+     *
+     * @param context
+     * @param session
+     * @return
+     */
     @Override
-    protected QueryBatchListener buildQueryBatchListener(final ProcessContext context, final ProcessSession session, final boolean consistentSnapshot) {
+    protected QueryBatchListener buildQueryBatchListener(final ProcessContext context, final ProcessSession session) {
         return new NiFiDeleteListener(session).onFailure((batch, throwable) -> {
             synchronized (session) {
                 getLogger().error("Error deleting batch", throwable);

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/util/QueryBatcherBuilder.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/util/QueryBatcherBuilder.java
@@ -1,0 +1,188 @@
+package org.apache.nifi.marklogic.processor.util;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.datamovement.DataMovementManager;
+import com.marklogic.client.datamovement.QueryBatcher;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.query.*;
+import org.apache.nifi.util.EscapeUtils;
+import org.apache.nifi.util.Tuple;
+
+import java.util.regex.Pattern;
+
+/**
+ * This class was extracted from {@code QueryMarkLogic} to both simplify that class and also make it easier to
+ * understand the logic for constructing a {@code QueryBatcher}. It is not yet intended for use outside this project
+ * as it still depends on a couple NiFi classes. Those dependencies could be easily removed though if necessary.
+ */
+public class QueryBatcherBuilder {
+
+    private DatabaseClient client;
+    private final static Pattern searchJson = Pattern.compile("^\\s*\\{\\s*\"(search|ctsquery)\"\\s*:\\s*");
+    private final static Pattern searchJsonEnd = Pattern.compile("\\}\\s*$");
+
+
+    public QueryBatcherBuilder(DatabaseClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Constructs a {@code QueryBatcher}, along with its associated {@code DataMovementManager}, based on the given
+     * query type and value. If {@code stateRangeIndexQuery} is not null, then it will be combined with the query
+     * constructed on the query type and value.
+     *
+     * @param queryTypeAndValue
+     * @param stateRangeIndexQuery can be null
+     * @return
+     */
+    public Tuple<DataMovementManager, QueryBatcher> newQueryBatcher(QueryTypeAndValue queryTypeAndValue, RangeIndexQuery stateRangeIndexQuery) {
+        DataMovementManager dataMovementManager = client.newDataMovementManager();
+        QueryManager queryManager = client.newQueryManager();
+
+        Tuple<QueryDefinition, Format> queryAndFormat = buildQueryDefinitionAndFormat(queryManager, queryTypeAndValue);
+
+        QueryBatcher queryBatcher;
+        if (stateRangeIndexQuery != null) {
+            String rawCombinedQuery = buildRawCombinedQueryWithStateQuery(queryAndFormat, queryTypeAndValue, stateRangeIndexQuery);
+            StringHandle handle = new StringHandle(rawCombinedQuery).withFormat(queryAndFormat.getValue());
+            RawCombinedQueryDefinition query = queryManager.newRawCombinedQueryDefinition(handle);
+            queryBatcher = dataMovementManager.newQueryBatcher(query);
+        } else {
+            final QueryDefinition queryDef = queryAndFormat.getKey();
+            if (queryDef instanceof RawCombinedQueryDefinition) {
+                queryBatcher = dataMovementManager.newQueryBatcher((RawCombinedQueryDefinition) queryDef);
+            } else if (queryDef instanceof RawStructuredQueryDefinition) {
+                queryBatcher = dataMovementManager.newQueryBatcher((RawStructuredQueryDefinition) queryDef);
+            } else if (queryDef instanceof StructuredQueryDefinition) {
+                queryBatcher = dataMovementManager.newQueryBatcher((StructuredQueryDefinition) queryDef);
+            } else {
+                queryBatcher = dataMovementManager.newQueryBatcher((StringQueryDefinition) queryDef);
+            }
+        }
+        return new Tuple<>(dataMovementManager, queryBatcher);
+    }
+
+    private Tuple<QueryDefinition, Format> buildQueryDefinitionAndFormat(QueryManager queryManager, QueryTypeAndValue queryTypeAndValue) {
+        QueryDefinition queryDef;
+        final String queryValue = queryTypeAndValue.value;
+        switch (queryTypeAndValue.type) {
+            case QueryTypes.COLLECTION_STR:
+                String[] collections = queryValue.split(",");
+                queryDef = queryManager.newStructuredQueryBuilder().collection(collections);
+                return new Tuple(queryDef, Format.XML);
+            case QueryTypes.COMBINED_JSON_STR:
+                queryDef = queryManager.newRawCombinedQueryDefinition(new StringHandle(queryValue).withFormat(Format.JSON));
+                return new Tuple(queryDef, Format.JSON);
+            case QueryTypes.COMBINED_XML_STR:
+                queryDef = queryManager.newRawCombinedQueryDefinition(new StringHandle(queryValue).withFormat(Format.XML));
+                return new Tuple(queryDef, Format.XML);
+            case QueryTypes.STRUCTURED_JSON_STR:
+                queryDef = queryManager.newRawStructuredQueryDefinition(new StringHandle(queryValue).withFormat(Format.JSON));
+                return new Tuple(queryDef, Format.JSON);
+            case QueryTypes.STRUCTURED_XML_STR:
+                queryDef = queryManager.newRawStructuredQueryDefinition(new StringHandle(queryValue).withFormat(Format.XML));
+                return new Tuple(queryDef, Format.XML);
+            default:
+                queryDef = queryManager.newStringDefinition().withCriteria(queryValue);
+                return new Tuple(queryDef, Format.XML);
+        }
+    }
+
+    /**
+     * Combines the user's NiFi-properties-based query with the given state query into a string representing the
+     * raw combined query.
+     *
+     * @param queryDefAndFormat
+     * @param queryTypeAndValue
+     * @param stateRangeIndexQuery
+     * @return
+     */
+    private String buildRawCombinedQueryWithStateQuery(Tuple<QueryDefinition, Format> queryDefAndFormat,
+                                                       QueryTypeAndValue queryTypeAndValue,
+                                                       RangeIndexQuery stateRangeIndexQuery) {
+        final QueryDefinition queryDef = queryDefAndFormat.getKey();
+        final Format format = queryDefAndFormat.getValue();
+        final String queryValue = queryTypeAndValue.value;
+
+        StringBuilder rawCombinedQueryBuilder = new StringBuilder();
+        if (queryDef instanceof StructuredQueryDefinition || queryDef instanceof RawStructuredQueryDefinition) {
+            rawCombinedQueryBuilder.append((format == Format.JSON) ? "{ \"search\": { "
+                : "<search xmlns=\"http://marklogic.com/appservices/search\">");
+            String queryBody;
+            if (queryDef instanceof StructuredQueryDefinition) {
+                queryBody = ((StructuredQueryDefinition) queryDef).serialize();
+            } else {
+                queryBody = queryValue;
+            }
+            if (format == Format.JSON) {
+                rawCombinedQueryBuilder
+                    .append("\"query\": {\"queries\": [ ")
+                    .append(stateRangeIndexQuery.toStructuredQuery(format))
+                    .append(",")
+                    .append(queryBody)
+                    .append("]}");
+            } else {
+                rawCombinedQueryBuilder
+                    .append("<query>")
+                    .append(stateRangeIndexQuery.toStructuredQuery(format))
+                    .append(queryBody)
+                    .append("</query>");
+            }
+            rawCombinedQueryBuilder.append((format == Format.JSON) ? "} }" : "</search>");
+        } else if (queryDef instanceof RawCombinedQueryDefinition) {
+            if (format == Format.XML) {
+                rawCombinedQueryBuilder
+                    .append("<cts:and-query xmlns:cts=\"http://marklogic.com/cts\">")
+                    .append(queryValue)
+                    .append(stateRangeIndexQuery.toCtsQuery(format))
+                    .append("</cts:and-query>");
+            } else {
+                rawCombinedQueryBuilder
+                    .append("{\"ctsquery\": { \"andQuery\": { \"queries\": [ ")
+                    .append(stateRangeIndexQuery.toCtsQuery(format))
+                    .append(",")
+                    .append(prepQueryToCombineJSON(queryValue))
+                    .append("]}}}");
+            }
+        } else if (queryDef instanceof StringQueryDefinition) {
+            rawCombinedQueryBuilder
+                .append("<search  xmlns=\"http://marklogic.com/appservices/search\">")
+                .append(stateRangeIndexQuery.toStructuredQuery(format))
+                .append("<qtext>").append(EscapeUtils.escapeHtml(queryValue))
+                .append("</qtext></search>");
+        }
+        return rawCombinedQueryBuilder.toString();
+    }
+
+    private String prepQueryToCombineJSON(String json) {
+        if (searchJson.matcher(json).lookingAt()) {
+            String newJSON = searchJsonEnd.matcher(searchJson.matcher(json).replaceFirst("")).replaceFirst("");
+            return (newJSON.equals(json)) ? json : prepQueryToCombineJSON(newJSON);
+        } else {
+            return json;
+        }
+    }
+
+    /**
+     * Simple tuple-like class for ferrying around the user's chosen query type and query value.
+     */
+    public static class QueryTypeAndValue {
+
+        private String type;
+        private String value;
+
+        public QueryTypeAndValue(String type, String value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/util/QueryTypes.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/util/QueryTypes.java
@@ -1,0 +1,29 @@
+package org.apache.nifi.marklogic.processor.util;
+
+import org.apache.nifi.components.AllowableValue;
+
+public class QueryTypes {
+    public static final String COLLECTION_STR = "Collection Query";
+    public static final AllowableValue COLLECTION = new AllowableValue(COLLECTION_STR, COLLECTION_STR,
+        "Comma-separated list of collections to query from a MarkLogic server");
+    public static final String COMBINED_JSON_STR = "Combined Query (JSON)";
+    public static final AllowableValue COMBINED_JSON = new AllowableValue(COMBINED_JSON_STR, COMBINED_JSON_STR,
+        "Combine a string or structured query with dynamic query options; also supports JSON serialized CTS queries");
+    public static final String COMBINED_XML_STR = "Combined Query (XML)";
+    public static final AllowableValue COMBINED_XML = new AllowableValue(COMBINED_XML_STR, COMBINED_XML_STR,
+        "Combine a string or structured query with dynamic query options; also supports XML serialized CTS queries");
+    public static final String STRING_STR = "String Query";
+    public static final AllowableValue STRING = new AllowableValue(STRING_STR, STRING_STR,
+        "A Google-style query string to search documents and metadata.");
+    public static final String STRUCTURED_JSON_STR = "Structured Query (JSON)";
+    public static final AllowableValue STRUCTURED_JSON = new AllowableValue(STRUCTURED_JSON_STR,
+        STRUCTURED_JSON_STR,
+        "A simple and easy way to construct queries as a JSON structure, allowing you to manipulate complex queries");
+    public static final String STRUCTURED_XML_STR = "Structured Query (XML)";
+    public static final AllowableValue STRUCTURED_XML = new AllowableValue(STRUCTURED_XML_STR, STRUCTURED_XML_STR,
+        "A simple and easy way to construct queries as a XML structure, allowing you to manipulate complex queries");
+
+    public static final AllowableValue[] allValues = new AllowableValue[]{COLLECTION, COMBINED_JSON, COMBINED_XML,
+        STRING, STRUCTURED_JSON, STRUCTURED_XML};
+
+}

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogicIT.java
@@ -24,6 +24,7 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.marklogic.processor.util.QueryTypes;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,7 @@ public class ApplyTransformMarkLogicIT extends AbstractMarkLogicIT {
             "  <cts:text xml:lang=\"en\">xmlcontent</cts:text>\n" +
             "</cts:element-value-query>";
         runner.setProperty(QueryMarkLogic.QUERY, queryStr);
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_XML);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COMBINED_XML);
         runner.setProperty(QueryMarkLogic.TRANSFORM, "AddAttribute");
         runner.setProperty("trans:name", "myAttr");
         runner.setProperty("trans:value", "myVal");

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/DeleteMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/DeleteMarkLogicIT.java
@@ -22,6 +22,7 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.StructuredQueryBuilder;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.marklogic.processor.util.QueryTypes;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +61,7 @@ public class DeleteMarkLogicIT extends AbstractMarkLogicIT {
     public void testSimpleCollectionDelete() {
         TestRunner runner = getNewTestRunner(DeleteMarkLogic.class);
         runner.setProperty(QueryMarkLogic.QUERY, collection);
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COLLECTION);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COLLECTION);
         runner.assertValid();
         runner.enqueue(new MockFlowFile(12345));
         runner.run();

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
@@ -26,6 +26,7 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.marklogic.processor.util.QueryTypes;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
@@ -80,7 +81,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     public void testSimpleCollectionQuery() {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.QUERY, TEST_COLLECTION);
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COLLECTION);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COLLECTION);
         runner.enqueue(new MockFlowFile(12345));
         runner.assertValid();
         runner.run();
@@ -148,7 +149,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "    }\n" +
             "  }\n" +
             "}");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_JSON);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COMBINED_JSON);
 
         verifyCombinedJSONQueryResults(runner);
     }
@@ -164,7 +165,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "      } \n" +
             "  }\n" +
             "} }");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_JSON);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COMBINED_JSON);
 
         verifyCombinedJSONQueryResults(runner);
     }
@@ -181,7 +182,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "  }\n" +
             "} }");
         runner.setProperty(QueryMarkLogic.RETURN_TYPE, QueryMarkLogic.ReturnTypes.DOCUMENTS_AND_META);
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_JSON);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COMBINED_JSON);
         testStateManagerJSON(runner, expectedJsonCount);
         runner.shutdown();
     }
@@ -201,7 +202,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "  <cts:element>sample</cts:element>\n" +
             "  <cts:text xml:lang=\"en\">xmlcontent</cts:text>\n" +
             "</cts:element-value-query>");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_XML);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COMBINED_XML);
         testStateManagerXML(runner, expectedXmlCount);
         runner.shutdown();
     }
@@ -222,7 +223,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "    ]\n" +
             "  }\n" +
             "}");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_JSON);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRUCTURED_JSON);
         testStateManagerJSON(runner, expectedJsonCount);
         runner.shutdown();
     }
@@ -237,7 +238,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "    <text>xmlcontent</text>\n" +
             "  </word-query>\n" +
             "</query>");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_XML);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRUCTURED_XML);
         testStateManagerXML(runner, expectedXmlCount);
         runner.shutdown();
     }
@@ -246,7 +247,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     public void testStateManagerWithJSONStringQuery() throws IOException {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.QUERY, "jsoncontent");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRING);
         testStateManagerJSON(runner, expectedJsonCount);
         runner.shutdown();
     }
@@ -256,7 +257,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     public void testStateManagerWithXMLStringQuery() throws IOException {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.QUERY, "xmlcontent");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRING);
         testStateManagerXML(runner, expectedXmlCount);
         runner.shutdown();
     }
@@ -271,7 +272,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "  <cts:element>sample</cts:element>\n" +
             "  <cts:text xml:lang=\"en\">xmlcontent</cts:text>\n" +
             "</cts:element-value-query>");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_XML);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COMBINED_XML);
 
         verifyCombinedXMLQueryResults(runner);
     }
@@ -288,7 +289,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "  </search:query>" +
             "</search:search>";
         runner.setProperty(QueryMarkLogic.QUERY, combinedQuery);
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COMBINED_XML);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COMBINED_XML);
 
         verifyCombinedXMLQueryResults(runner);
     }
@@ -309,7 +310,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "    ]\n" +
             "  }\n" +
             "}");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_JSON);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRUCTURED_JSON);
         runner.assertValid();
         runner.run();
         runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedJsonCount);
@@ -341,7 +342,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             "    <text>${word}</text>\n" +
             "  </word-query>\n" +
             "</query>");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRUCTURED_XML);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRUCTURED_XML);
         runner.assertValid();
         runner.run();
 
@@ -370,7 +371,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     public void testStringQuery() {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.QUERY, "xmlcontent");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRING);
         runner.assertValid();
         runner.run();
         runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedXmlCount);
@@ -395,7 +396,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.RETURN_TYPE, QueryMarkLogic.ReturnTypes.URIS_ONLY);
         runner.setProperty(QueryMarkLogic.QUERY, "xmlcontent");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRING);
         runner.assertValid();
         runner.run();
         runner.assertTransferCount(QueryMarkLogic.SUCCESS, expectedXmlCount);
@@ -422,7 +423,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
             TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
             runner.setProperty(QueryMarkLogic.RETURN_TYPE, QueryMarkLogic.ReturnTypes.META);
             runner.setProperty(QueryMarkLogic.QUERY, uniqueString);
-            runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING);
+            runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRING);
             runner.assertValid();
             runner.run();
 
@@ -451,7 +452,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.RETURN_TYPE, QueryMarkLogic.ReturnTypes.META);
         runner.setProperty(QueryMarkLogic.QUERY, "xmlcontent");
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.STRING);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.STRING);
         runner.assertValid();
         runner.run();
 
@@ -488,11 +489,11 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     public void testJobProperties() {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         runner.setProperty(QueryMarkLogic.QUERY, TEST_COLLECTION);
-        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryMarkLogic.QueryTypes.COLLECTION);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COLLECTION);
         runner.run();
         Processor processor = runner.getProcessor();
         if (processor instanceof QueryMarkLogic) {
-            QueryBatcher queryBatcher = ((QueryMarkLogic) processor).getQueryBatcher();
+            QueryBatcher queryBatcher = ((QueryMarkLogic) processor).getQueryBatcherForTesting();
             assertEquals(Integer.parseInt(batchSize), queryBatcher.getBatchSize());
             assertEquals(Integer.parseInt(threadCount), queryBatcher.getThreadCount());
         } else {


### PR DESCRIPTION
No change in functionality, just extracted a lot of methods and added some comments to improve the readability of the code. Also reordered the methods in QueryMarkLogic to make it read more top-to-bottom. 

Notably, QueryBatcherBuilder was extracted into a separate class to make it and QueryMarkLogic easier to understand. It is not intended yet for reuse outside of this project though, it's just an attempt to simplify the code a bit. 

