### PR TITLE
Feature/devexp64 remove requires input

### DIFF
--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogicIT.java
@@ -20,7 +20,6 @@ public class CallRestExtensionMarkLogicIT extends AbstractMarkLogicIT {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(CallRestExtensionMarkLogic.EXTENSION_NAME, "multipleItems");
         runner.setProperty(CallRestExtensionMarkLogic.METHOD_TYPE, CallRestExtensionMarkLogic.MethodTypes.GET_STR);
-        runner.setProperty(CallRestExtensionMarkLogic.REQUIRES_INPUT, "false");
 
         runner.run();
         runner.assertQueueEmpty();
@@ -82,7 +81,6 @@ public class CallRestExtensionMarkLogicIT extends AbstractMarkLogicIT {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(CallRestExtensionMarkLogic.EXTENSION_NAME, "multipleItems");
         runner.setProperty(CallRestExtensionMarkLogic.METHOD_TYPE, CallRestExtensionMarkLogic.MethodTypes.POST_STR);
-        runner.setProperty(CallRestExtensionMarkLogic.REQUIRES_INPUT, "false");
 
         runner.run();
         runner.assertQueueEmpty();

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
@@ -37,16 +37,14 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(ExtensionCallMarkLogic.EXTENSION_NAME, "replay");
         runner.setProperty(ExtensionCallMarkLogic.METHOD_TYPE, ExtensionCallMarkLogic.MethodTypes.GET_STR);
-        runner.setProperty(ExtensionCallMarkLogic.REQUIRES_INPUT, "true");
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_SOURCE, ExtensionCallMarkLogic.PayloadSources.NONE);
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_FORMAT, Format.TEXT.name());
         runner.setProperty("param:replay", "${dynamicParam}");
 
         runner.run();
         assertEquals(0, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.FAILURE).size());
-        assertEquals(0, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size(),
-            "Expecting no FlowFiles; the processor should not have run since requiresInput=true and no " +
-                "FlowFile was enqueued");
+        assertEquals(1, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size(),
+            "Expecting 1 FlowFile; the processor should run once since a FlowFile was generated and enqueued");
 
         MockFlowFile mockFlowFile = new MockFlowFile(1);
         Map<String, String> attributes = new HashMap<>();
@@ -58,12 +56,12 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
 
         runner.assertQueueEmpty();
         assertEquals(0, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.FAILURE).size());
-        assertEquals(1, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size());
+        assertEquals(2, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS).size());
 
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS);
-        assertEquals(1, results.size());
+        assertEquals(2, results.size());
 
-        MockFlowFile result = results.get(0);
+        MockFlowFile result = results.get(1);
         String resultValue = new String(runner.getContentAsByteArray(result));
         assertEquals("dynamicValue", resultValue,
             "The test 'replay' extension is expected to return the value of the 'replay' parameter, " +
@@ -78,7 +76,6 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(ExtensionCallMarkLogic.EXTENSION_NAME, "replay");
         runner.setProperty(ExtensionCallMarkLogic.METHOD_TYPE, ExtensionCallMarkLogic.MethodTypes.POST_STR);
-        runner.setProperty(ExtensionCallMarkLogic.REQUIRES_INPUT, "true");
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_SOURCE, ExtensionCallMarkLogic.PayloadSources.FLOWFILE_CONTENT_STR);
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_FORMAT, Format.TEXT.name());
 
@@ -105,7 +102,6 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(ExtensionCallMarkLogic.EXTENSION_NAME, "throwsError");
         runner.setProperty(ExtensionCallMarkLogic.METHOD_TYPE, ExtensionCallMarkLogic.MethodTypes.GET_STR);
-        runner.setProperty(ExtensionCallMarkLogic.REQUIRES_INPUT, "false");
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_SOURCE, ExtensionCallMarkLogic.PayloadSources.NONE);
 
         runner.enqueue();
@@ -170,7 +166,6 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(ExtensionCallMarkLogic.EXTENSION_NAME, "emptyEndpoints");
         runner.setProperty(ExtensionCallMarkLogic.METHOD_TYPE, methodType);
-        runner.setProperty(ExtensionCallMarkLogic.REQUIRES_INPUT, "true");
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_SOURCE, ExtensionCallMarkLogic.PayloadSources.NONE);
         return runner;
     }

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicTest.java
@@ -38,13 +38,12 @@ public class ExtensionCallMarkLogicTest extends AbstractMarkLogicProcessorTest {
     }
 
     @Test
-    public void testValidator() throws Exception {
+    public void testValidator() {
         runner.enableControllerService(service);
         runner.assertValid(service);
         runner.assertNotValid();
 
         runner.setProperty(TestExtensionCallMarkLogic.EXTENSION_NAME, "extension");
-        runner.setProperty(TestExtensionCallMarkLogic.REQUIRES_INPUT, "true");
         runner.setProperty(TestExtensionCallMarkLogic.PAYLOAD_SOURCE, PayloadSources.NONE);
         runner.setProperty(TestExtensionCallMarkLogic.PAYLOAD_FORMAT, Format.TEXT.name());
         runner.setProperty(TestExtensionCallMarkLogic.METHOD_TYPE, MethodTypes.POST);
@@ -56,7 +55,6 @@ public class ExtensionCallMarkLogicTest extends AbstractMarkLogicProcessorTest {
         runner.enableControllerService(service);
 
         runner.setProperty(TestExtensionCallMarkLogic.EXTENSION_NAME, "example-rest");
-        runner.setProperty(TestExtensionCallMarkLogic.REQUIRES_INPUT, "false");
         runner.setProperty(TestExtensionCallMarkLogic.PAYLOAD_SOURCE, PayloadSources.FLOWFILE_CONTENT_STR);
         runner.setProperty(TestExtensionCallMarkLogic.PAYLOAD_FORMAT, Format.TEXT.name());
         runner.setProperty(TestExtensionCallMarkLogic.METHOD_TYPE, MethodTypes.PUT_STR);


### PR DESCRIPTION
devexp64 - remove requires input
https://project.marklogic.com/jira/browse/DEVEXP-64 Run ExtensionCallML and CallRestExtensionML without "Requires Input" property