### PR TITLE
DEVEXP-44: DeleteML creates new FlowFiles from incoming FlowFile

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogic.java
@@ -30,10 +30,7 @@ import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
-import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
-import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.*;
 import org.apache.nifi.processor.util.StandardValidators;
 
 import java.util.*;
@@ -92,10 +89,11 @@ public class ApplyTransformMarkLogic extends QueryMarkLogic {
      *
      * @param context
      * @param session
+     * @param incomingAttributes
      * @return
      */
     @Override
-    protected QueryBatchListener buildQueryBatchListener(final ProcessContext context, final ProcessSession session) {
+    protected QueryBatchListener buildQueryBatchListener(final ProcessContext context, final ProcessSession session, Map<String, String> incomingAttributes) {
         ApplyTransformListener applyTransform = new ApplyTransformListener()
             .withApplyResult(
                 ApplyResultTypes.INGORE_STR.equals(context.getProperty(APPLY_RESULT_TYPE).getValue()) ? ApplyResult.IGNORE : ApplyResult.REPLACE

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
@@ -126,7 +126,7 @@ public abstract class AbstractMarkLogicIT extends AbstractSpringMarkLogicTest {
         }
     }
 
-    protected void addDatabaseClientService(TestRunner runner) {
+    private void addDatabaseClientService(TestRunner runner, String username, String password) {
         service = new DefaultMarkLogicDatabaseClientService();
         try {
             runner.addControllerService(databaseClientServiceIdentifier, service);
@@ -135,14 +135,18 @@ public abstract class AbstractMarkLogicIT extends AbstractSpringMarkLogicTest {
         }
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.HOST, testConfig.getHost());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PORT, testConfig.getRestPort().toString());
-        runner.setProperty(service, DefaultMarkLogicDatabaseClientService.USERNAME, testConfig.getUsername());
-        runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PASSWORD, testConfig.getPassword());
+        runner.setProperty(service, DefaultMarkLogicDatabaseClientService.USERNAME, username);
+        runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PASSWORD, password);
         runner.enableControllerService(service);
     }
 
     protected TestRunner getNewTestRunner(Class<? extends Processor> processor) {
+        return getNewTestRunner(processor, testConfig.getUsername(), testConfig.getPassword());
+    }
+
+    protected TestRunner getNewTestRunner(Class<? extends Processor> processor, String username, String password) {
         TestRunner runner = TestRunners.newTestRunner(processor);
-        addDatabaseClientService(runner);
+        addDatabaseClientService(runner, username, password);
         runner.setProperty(AbstractMarkLogicProcessor.BATCH_SIZE, batchSize);
         runner.setProperty(AbstractMarkLogicProcessor.THREAD_COUNT, threadCount);
         assertTrue(runner.isControllerServiceEnabled(service));

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/DeleteMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/DeleteMarkLogicIT.java
@@ -28,29 +28,28 @@ import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DeleteMarkLogicIT extends AbstractMarkLogicIT {
-    private String collection;
+
+    private final static String COLLECTION = "DeleteMarkLogicIT";
 
     @BeforeEach
     public void setup() {
         super.setup();
-        collection = "QueryMarkLogicTest";
-        // Load documents to Query
-        loadDocumentsIntoCollection(collection, documents);
-    }
 
-    private void loadDocumentsIntoCollection(String collection, List<IngestDoc> documents) {
         WriteBatcher writeBatcher = dataMovementManager.newWriteBatcher()
             .withBatchSize(3)
             .withThreadCount(3);
         dataMovementManager.startJob(writeBatcher);
         for (IngestDoc document : documents) {
             DocumentMetadataHandle handle = new DocumentMetadataHandle();
-            handle.withCollections(collection);
+            handle.withPermission("rest-reader", DocumentMetadataHandle.Capability.READ);
+            handle.withPermission("rest-writer", DocumentMetadataHandle.Capability.UPDATE);
+            handle.withCollections(COLLECTION);
             writeBatcher.add(document.getFileName(), handle, new StringHandle(document.getContent()));
         }
         writeBatcher.flushAndWait();
@@ -60,22 +59,84 @@ public class DeleteMarkLogicIT extends AbstractMarkLogicIT {
     @Test
     public void testSimpleCollectionDelete() {
         TestRunner runner = getNewTestRunner(DeleteMarkLogic.class);
-        runner.setProperty(QueryMarkLogic.QUERY, collection);
+        runner.setProperty(QueryMarkLogic.QUERY, COLLECTION);
         runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COLLECTION);
         runner.assertValid();
-        runner.enqueue(new MockFlowFile(12345));
+
+        MockFlowFile incomingFlowFile = new MockFlowFile(12345);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "world");
+        incomingFlowFile.putAttributes(attributes);
+
+        runner.enqueue(incomingFlowFile);
         runner.run();
 
         runner.assertTransferCount(QueryMarkLogic.SUCCESS, numDocs);
         runner.assertAllFlowFilesContainAttribute(QueryMarkLogic.SUCCESS, CoreAttributes.FILENAME.key());
+        runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS).forEach(flowFile -> {
+            assertEquals("world", flowFile.getAttribute("hello"));
+        });
 
         runner.assertTransferCount(QueryMarkLogic.ORIGINAL, 1);
         MockFlowFile originalFlowFile = runner.getFlowFilesForRelationship(QueryMarkLogic.ORIGINAL).get(0);
         assertEquals(12345, originalFlowFile.getId(), "If a FlowFile is passed to DeleteML/QueryML, it is expected to be sent to the " +
             "ORIGINAL relationship before the job completes");
 
-        try(DocumentPage page = getDatabaseClient().newDocumentManager().search(new StructuredQueryBuilder().collection(collection), 1)) {
+        try (DocumentPage page = getDatabaseClient().newDocumentManager().search(new StructuredQueryBuilder().collection(COLLECTION), 1)) {
             assertEquals(0, page.getTotalSize());
         }
+    }
+
+    @Test
+    public void deleteWithNoIncomingFlowFile() {
+        TestRunner runner = getNewTestRunner(DeleteMarkLogic.class);
+        runner.setProperty(QueryMarkLogic.QUERY, COLLECTION);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COLLECTION);
+        runner.assertValid();
+        runner.run();
+
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, numDocs);
+        runner.assertTransferCount(QueryMarkLogic.ORIGINAL, 1);
+        MockFlowFile originalFlowFile = runner.getFlowFilesForRelationship(QueryMarkLogic.ORIGINAL).get(0);
+        assertNotNull(originalFlowFile.getAttribute("marklogic-query"), "The marklogic-query attribute should still be " +
+            "set on the original FlowFile when no incoming one exists");
+
+        Map<String, String> attributes = runner.getFlowFilesForRelationship(QueryMarkLogic.SUCCESS).get(0).getAttributes();
+        // If this count changes in the future, it may simply be due to a new NiFi release that includes an additional
+        // key. In the meantime, this is a useful sanity check.
+        assertEquals(3, attributes.size(), "Expecting each new FF to have 3 keys - path, filename, and uuid");
+        assertTrue(attributes.containsKey("path"));
+        assertTrue(attributes.containsKey("filename"));
+        assertTrue(attributes.containsKey("uuid"));
+    }
+
+    @Test
+    public void userCanReadButNotUpdate() {
+        TestRunner runner = getNewTestRunner(DeleteMarkLogic.class, "nifi-reader", "x");
+        runner.setProperty(QueryMarkLogic.QUERY, COLLECTION);
+        runner.setProperty(QueryMarkLogic.QUERY_TYPE, QueryTypes.COLLECTION);
+        runner.assertValid();
+
+        MockFlowFile incomingFlowFile = new MockFlowFile(12345);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("hello", "world");
+        incomingFlowFile.putAttributes(attributes);
+
+        runner.enqueue(incomingFlowFile);
+        runner.run();
+
+        // The incoming FlowFile should still be sent along, as the processor doesn't know if only some docs fail to be
+        // deleted
+        runner.assertTransferCount(QueryMarkLogic.ORIGINAL, 1);
+
+        runner.assertTransferCount(QueryMarkLogic.SUCCESS, 0);
+
+        runner.assertTransferCount(QueryMarkLogic.FAILURE, numDocs);
+        runner.getFlowFilesForRelationship(QueryMarkLogic.FAILURE).forEach(flowFile -> {
+            assertEquals("world", flowFile.getAttribute("hello"));
+            String message = flowFile.getAttribute("markLogicErrorMessage");
+            assertTrue(message.contains("User is not allowed to delete resource at documents"),
+                "Unexpected message: " + message);
+        });
     }
 }

--- a/nifi-marklogic-processors/src/test/ml-config/security/users/nifi-reader.json
+++ b/nifi-marklogic-processors/src/test/ml-config/security/users/nifi-reader.json
@@ -1,0 +1,8 @@
+{
+  "user-name": "nifi-reader",
+  "description": "test user for marklogic-nifi",
+  "role": [
+    "rest-reader"
+  ],
+  "password": "x"
+}


### PR DESCRIPTION
Realized during testing that as a result of creating a new FlowFile from the incoming FlowFile, we can't call commitAsync in the middle of `onTrigger` as that prevents more FlowFiles from being created from the incoming one.

As a result, reworked several processors so that they only call `commitAsync()` once - at the end of `onTrigger`, regardless of whether an error occurs or not. 

Also added a missing test scenario for `DeleteMarkLogic` where the user is able to read URIs but not delete them. This tests the "on batch failure" listener in `DeleteMarkLogic`. 