### PR TITLE
DEVEXP-81: Improved docs for ExtensionCall and CallRestExtension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ function nifirebuild {
   $NIFI_HOME/bin/nifi stop
   mvn clean install -DskipTests
   rm -f $NIFI_HOME/libexec/lib/nifi-marklogic*
+  rm -rf $NIFI_HOME/libexec/work/docs/components/org.apache.nifi/nifi-marklogic-nar
   cp nifi-marklogic-nar/target/nifi-marklogic-nar-*.nar $NIFI_HOME/libexec/lib
   cp nifi-marklogic-services-api-nar/target/nifi-marklogic-services-api-nar-*.nar $NIFI_HOME/libexec/lib
   $NIFI_HOME/bin/nifi start
@@ -82,6 +83,11 @@ function nifirebuild {
 
 Based on how you've installed NiFi, you may need to adjust the NAR library path - i.e. `$NIFI_HOME/libexec/lib` will 
 work if you've installed NiFi homebrew, but otherwise, you likely will need `$NIFI_HOME/lib`.
+
+A note on the above script - the reason for deleting the `libexec/work/docs/components/org.apache.nifi/nifi-marklogic-nar`
+directory is to ensure that changes to documentation in the connector components can be verified after a rebuild. 
+Otherwise, NiFi appears to cache connector documentation for a particular version in this directory, and that cache 
+is not updated when the connector is modified. 
 
 ## Running the tests
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogic.java
@@ -38,7 +38,7 @@ public class CallRestExtensionMarkLogic extends ExtensionCallMarkLogic {
             "attributes from the incoming FlowFile if one exists.").build();
 
     protected static final Relationship ORIGINAL = new Relationship.Builder().name("original")
-        .description("The original FlowFile - either the incoming one or a new one if 'Requires Input' is false - " +
+        .description("The original FlowFile - either the incoming one or a new one - " +
             "will be sent here after the extension call to MarkLogic is completed.").build();
 
 

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
@@ -40,6 +40,7 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_SOURCE, ExtensionCallMarkLogic.PayloadSources.NONE);
         runner.setProperty(ExtensionCallMarkLogic.PAYLOAD_FORMAT, Format.TEXT.name());
         runner.setProperty("param:replay", "${dynamicParam}");
+        runner.setProperty("separator:param:replay", ",");
 
         runner.run();
         assertEquals(0, runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.FAILURE).size());
@@ -48,7 +49,7 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
 
         MockFlowFile mockFlowFile = new MockFlowFile(1);
         Map<String, String> attributes = new HashMap<>();
-        attributes.put("dynamicParam", "dynamicValue");
+        attributes.put("dynamicParam", "dynamic,Value");
         mockFlowFile.putAttributes(attributes);
 
         runner.enqueue(mockFlowFile);
@@ -62,11 +63,11 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
 
         MockFlowFile result = results.get(1);
         String resultValue = new String(runner.getContentAsByteArray(result));
-        assertEquals("dynamicValue", resultValue,
+        assertEquals("dynamic Value", resultValue,
             "The test 'replay' extension is expected to return the value of the 'replay' parameter, " +
                 "which is sent via the replay:param property. That property then has an expression, " +
-                "which is expected to be evaluated against the flowfile attributes, producing the " +
-                "value 'dynamicvalue'");
+                "which is expected to be evaluated against the flowfile attributes. The value is then " +
+                "expected to be separated via the separator:param:replay attribute");
     }
 
     @Test


### PR DESCRIPTION
Also improved ExtensionCallMarkLogicIT so that it tests the "separator:param" feature, which was previously untested. 