### PR TITLE
Standardizing on use of createFlowFileWithAttributes

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogic.java
@@ -69,7 +69,7 @@ public class CallRestExtensionMarkLogic extends ExtensionCallMarkLogic {
         }
         try {
             while (results.hasNext()) {
-                FlowFile resultFlowFile = session.create(originalFlowFile);
+                FlowFile resultFlowFile = createFlowFileWithAttributes(session, originalFlowFile.getAttributes());
                 session.write(resultFlowFile, out -> out.write(results.next().getContent(new BytesHandle()).get()));
                 session.transfer(resultFlowFile, RESULTS);
             }

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
@@ -150,16 +150,16 @@ public class ExtensionCallMarkLogic extends AbstractMarkLogicProcessor {
     public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
         final ProcessSession session = sessionFactory.createSession();
 
-        FlowFile originalFlowFile = session.get();
-        if (originalFlowFile == null) {
-            originalFlowFile = session.create();
+        FlowFile incomingFlowFile = session.get();
+        if (incomingFlowFile == null) {
+            incomingFlowFile = session.create();
         }
 
         try {
-            ServiceResultIterator results = callExtension(context, session, originalFlowFile);
-            handleExtensionCallResults(results, session, originalFlowFile);
+            ServiceResultIterator results = callExtension(context, session, incomingFlowFile);
+            handleExtensionCallResults(results, session, incomingFlowFile);
         } catch (Throwable t) {
-            logErrorAndTransfer(t, originalFlowFile, session, FAILURE);
+            logErrorAndTransfer(t, incomingFlowFile, session, FAILURE);
         }
     }
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
@@ -312,7 +312,8 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
          * likely never be invoked, and certainly not on account of a query failure. This is here only in the
          * extremely unlikely event that a listener is invoked.
          */
-        queryBatcher.onQueryFailure(ex -> logErrorAndTransfer(ex, session.create(), session, FAILURE));
+        queryBatcher.onQueryFailure(ex ->
+            logErrorAndTransfer(ex, createFlowFileWithAttributes(session, attributesToCopy), session, FAILURE));
     }
 
     /**

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogic.java
@@ -91,7 +91,7 @@ public class QueryRowsMarkLogic extends AbstractMarkLogicProcessor {
                         .get()) {
                     if (inputStream != null) {
                         FlowFile resultFlowFile = session.write(
-                            session.create(incomingFlowFile),
+                            createFlowFileWithAttributes(session, incomingFlowFile.getAttributes()),
                             out -> FileCopyUtils.copy(inputStream, out));
                         session.transfer(resultFlowFile, SUCCESS);
                     }

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
@@ -140,13 +140,13 @@ public class RunFlowMarkLogic extends AbstractMarkLogicProcessor {
     public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
         final ProcessSession session = sessionFactory.createSession();
 
-        FlowFile flowFile = session.get();
-        if (flowFile == null) {
-            flowFile = session.create();
+        FlowFile incomingFlowFile = session.get();
+        if (incomingFlowFile == null) {
+            incomingFlowFile = session.create();
         }
 
         try {
-            FlowInputs inputs = buildFlowInputs(context, flowFile);
+            FlowInputs inputs = buildFlowInputs(context, incomingFlowFile);
             FlowRunner flowRunner = new FlowRunnerImpl(hubConfig);
             if (inputs.getSteps() != null) {
                 getLogger().info(String.format("Running steps %s in flow %s", inputs.getSteps(), inputs.getFlowName()));
@@ -162,8 +162,8 @@ public class RunFlowMarkLogic extends AbstractMarkLogicProcessor {
                 getLogger().info(String.format("Finished running flow %s", inputs.getFlowName()));
             }
 
-            session.write(flowFile, out -> out.write(response.toJson().getBytes()));
-            transferAndCommit(session, flowFile, FINISHED);
+            session.write(incomingFlowFile, out -> out.write(response.toJson().getBytes()));
+            transferAndCommit(session, incomingFlowFile, FINISHED);
         } catch (Throwable t) {
             this.logErrorAndRollbackSession(t, session);
         }


### PR DESCRIPTION
The intent is to make it easier in a future release to support the generation of a RECEIVE provenance event. 

This also ensures that FORK or JOIN provenance events are not created, as per the NiFi javadocs, those are not appropriate when creating new FlowFiles based on data received from an external system (MarkLogic). 

Also did some renaming to standardize on `incomingFlowFile` as a variable name. 