### PR TITLE
Added some docs and did some renaming in PutMarkLogic

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
@@ -214,16 +214,16 @@ public class PutMarkLogicRecord extends PutMarkLogic {
     }
 
     @Override
-    protected void routeDocumentToRelationship(WriteEvent writeEvent, Relationship relationship) {
+    protected void transferFlowFile(WriteEvent writeEvent, Relationship relationship) {
         FlowFileInfo flowFileInfo = getFlowFileInfoForWriteEvent(writeEvent);
         if (flowFileInfo != null) {
+            if (getLogger().isDebugEnabled()) {
+                getLogger().debug("Routing " + writeEvent.getTargetUri() + " to " + relationship.getName());
+            }
             synchronized (flowFileInfo.session) {
                 FlowFile flowFile = flowFileInfo.session.create();
                 flowFileInfo.session.getProvenanceReporter().send(flowFile, writeEvent.getTargetUri());
                 flowFileInfo.session.transfer(flowFile, relationship);
-            }
-            if (getLogger().isDebugEnabled()) {
-                getLogger().debug("Routing " + writeEvent.getTargetUri() + " to " + relationship.getName());
             }
         }
     }

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
@@ -153,7 +153,7 @@ class TestDuplicatePutMarkLogic extends PutMarkLogic {
     }
 
     @Override
-    protected void routeDocumentToRelationship(WriteEvent writeEvent, Relationship relationship) {
+    protected void transferFlowFile(WriteEvent writeEvent, Relationship relationship) {
         String relName = relationship.getName();
         FlowFileInfo fileInfo = getFlowFileInfoForWriteEvent(writeEvent);
         int relCtr = relationsMap.get(relName) != null ? relationsMap.get(relName) : 0;
@@ -163,7 +163,7 @@ class TestDuplicatePutMarkLogic extends PutMarkLogic {
             lastSupersededUUID = fileInfo.flowFile.getAttribute(CoreAttributes.UUID.key());
         }
         //Just route to super to ensure it works properly
-        super.routeDocumentToRelationship(writeEvent, relationship);
+        super.transferFlowFile(writeEvent, relationship);
     }
 
     @Override


### PR DESCRIPTION
Also moved the logic for transferring all "success" FlowFiles outside the block that performs the "batch success" transfer. In practice, the change should never matter - i.e. we always expect to find a FlowFile for the first WriteEvent in a batch. But in theory, that may not happen, and we wouldn't want that to prevent every other WriteEvent in the batch from being processed. 