### PR TITLE
DEVEXP-140 Upgraded to Java Client 6.2.1

### DIFF
--- a/nifi-marklogic-processors/build.gradle
+++ b/nifi-marklogic-processors/build.gradle
@@ -4,5 +4,5 @@
  */
 plugins {
   id 'net.saliman.properties' version '1.5.2'
-  id 'com.marklogic.ml-gradle' version '4.3.5'
+  id 'com.marklogic.ml-gradle' version '4.5.2'
 }

--- a/nifi-marklogic-processors/gradle/wrapper/gradle-wrapper.properties
+++ b/nifi-marklogic-processors/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/nifi-marklogic-processors/pom.xml
+++ b/nifi-marklogic-processors/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>ml-app-deployer</artifactId>
-      <version>4.3.4</version>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>com.marklogic</groupId>
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.11</version>
+      <version>1.3.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
@@ -25,6 +25,7 @@ import com.marklogic.client.ext.util.DefaultDocumentPermissionsParser;
 import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.io.StringHandle;
+import com.marklogic.rest.util.Fragment;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -32,6 +33,7 @@ import org.apache.nifi.marklogic.processor.util.QueryTypes;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
+import org.jdom2.Namespace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -42,9 +44,18 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class QueryMarkLogicIT extends AbstractMarkLogicIT {
 
@@ -116,8 +127,11 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
      */
     private void verifySimpleCollectionQueryResult(TestRunner runner) {
         MockFlowFile originalFlowFile = runner.getFlowFilesForRelationship(QueryMarkLogic.ORIGINAL).get(0);
+
         final String query = originalFlowFile.getAttribute("marklogic-query");
-        assertTrue(query.contains("<collection-query><uri>" + TEST_COLLECTION + "</uri></collection-query>"),
+        Fragment xmlQuery = new Fragment(query, Namespace.getNamespace("search", "http://marklogic.com/appservices/search"));
+
+        assertEquals(TEST_COLLECTION, xmlQuery.getElementValue("/search:query/search:collection-query/search:uri"),
             "The query should be saved as an attribute so that the user has evidence of what query was actually used; " +
                 "query: " + query);
 

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestMLDatabaseClient.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestMLDatabaseClient.java
@@ -31,7 +31,7 @@ class TestMLDatabaseClient extends DatabaseClientImpl {
     private ServerEvaluationCall serverEval = new TestServerEvaluationCall();
 
     public TestMLDatabaseClient() {
-        super(services, "", 0, "", null, ConnectionType.DIRECT);
+        super(services, "", 0, "", null, null, ConnectionType.DIRECT);
     }
 
     @Override

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestQueryBatcher.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestQueryBatcher.java
@@ -260,4 +260,8 @@ class TestQueryBatcher implements QueryBatcher {
         return 1;
     }
 
+    @Override
+    public Long getServerTimestamp() {
+        return null;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <maven.compiler.release>8</maven.compiler.release>
     <nifi.version>1.16.3</nifi.version>
     <marklogicnar.version>1.16.3.2</marklogicnar.version>
-    <marklogicclientapi.version>5.5.3</marklogicclientapi.version>
+    <marklogicclientapi.version>6.2.1</marklogicclientapi.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Bumped up ml-app-deployer as well to stay aligned on 6.2.1. Leaving DHF alone for now since need to test if DHF 5.8.1 can run against existing DHF 5.7 deployments.