### PR TITLE
DEVEXP-129 PutML and RunFlowML now have better error handling

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
@@ -16,7 +16,11 @@
  */
 package org.apache.nifi.marklogic.processor;
 
-import com.marklogic.client.*;
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.ForbiddenUserException;
+import com.marklogic.client.MarkLogicBindingException;
+import com.marklogic.client.ResourceNotFoundException;
+import com.marklogic.client.UnauthorizedUserException;
 import com.marklogic.client.document.ServerTransform;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.Validator;
@@ -24,11 +28,19 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.marklogic.controller.MarkLogicDatabaseClientService;
-import org.apache.nifi.processor.*;
-import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.AbstractSessionFactoryProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Pattern;
@@ -216,21 +228,6 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return properties;
-    }
-
-    /**
-     * Use this when you want an error to result in the session being rolled back and a ProcessException being
-     * thrown. Note that this should result in an incoming FlowFile being left in the queue before the processor. This
-     * may not be desirable to a user; it may be better to route the FlowFile to a failure relationship.
-     *
-     * @param t
-     * @param session
-     */
-    protected void logErrorAndRollbackSession(final Throwable t, final ProcessSession session) {
-        logError(t);
-        getLogger().info("Rolling back session");
-        session.rollback(true);
-        throw new ProcessException(t);
     }
 
     /**

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogicIT.java
@@ -1,0 +1,33 @@
+package org.apache.nifi.marklogic.processor;
+
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The test app does not yet have a DHF application available within it - it would really need to be converted into a
+ * DHF application to make that feasible. For now, just verifying error handling in the processor.
+ */
+public class RunFlowMarkLogicIT extends AbstractMarkLogicIT {
+
+    @Test
+    void flowDoesntExist() {
+        TestRunner runner = newReaderTestRunner(RunFlowMarkLogic.class);
+        runner.setProperty(RunFlowMarkLogic.FLOW_NAME, "doesntExist");
+        runner.run();
+
+        assertEquals(0, runner.getFlowFilesForRelationship(RunFlowMarkLogic.FINISHED).size());
+
+        List<MockFlowFile> files = runner.getFlowFilesForRelationship(RunFlowMarkLogic.FAILURE);
+        assertEquals(1, files.size());
+        String errorMessage = files.get(0).getAttribute("markLogicErrorMessage");
+        assertTrue(errorMessage.startsWith("Unable to retrieve flow with name: doesntExist"),
+            "Expecting the processor to fail because the flow can't be found, since the test doesn't even run " +
+                "against a DHF application; error message: " + errorMessage);
+    }
+}


### PR DESCRIPTION
All failures are now sent to a FAILURE relationship with the `markLogicErrorMessage` attribute capturing the error message.