### PR TITLE
MLE-14335 Ensuring batcher is not flushed when it has been stopped

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
@@ -203,7 +203,7 @@ public class PutMarkLogicRecord extends PutMarkLogic {
                 String url = client != null
                     ? client.getHost() + ":" + client.getPort()
                     : "MarkLogic cluster";
-                writeBatcher.flushAndWait();
+                flushAndWaitWithoutFailing(writeBatcher);
                 session.getProvenanceReporter().send(flowFile, url, String.format("Added %d documents to MarkLogic.", added));
                 session.transfer(flowFile, ORIGINAL);
                 uriFlowFileMap.remove(flowFile.getAttribute(CoreAttributes.UUID.key()));


### PR DESCRIPTION
Have not been able to reproduce this behavior, which is why there's no automated test for this yet. The thought is that this will at least avoid some problems, as trying to flush a stopped batcher is not a good reason to throw an error. 