### PR TITLE
MLE-14335 Improving error handling for when batcher is stopped

### DIFF
--- a/nifi-marklogic-processors/pom.xml
+++ b/nifi-marklogic-processors/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>ml-app-deployer</artifactId>
-      <version>4.6.1</version>
+      <version>4.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.marklogic</groupId>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.marklogic</groupId>
       <artifactId>marklogic-data-hub</artifactId>
-      <version>5.7.2</version>
+      <version>5.8.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.nifi</groupId>
@@ -137,13 +137,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.36</version>
+      <version>2.0.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
+      <version>2.0.13</version>
       <scope>test</scope>
     </dependency>
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
@@ -254,12 +254,16 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
      * @param session
      * @param relationship
      */
-    protected void logErrorAndTransfer(Throwable t, FlowFile flowFile, ProcessSession session, Relationship relationship) {
+    protected final void logErrorAndTransfer(Throwable t, FlowFile flowFile, ProcessSession session, Relationship relationship) {
         logError(t);
+        addErrorMessageToFlowFile(t, flowFile, session);
+        transferAndCommit(session, flowFile, relationship);
+    }
+
+    protected final void addErrorMessageToFlowFile(Throwable t, FlowFile flowFile, ProcessSession session) {
         if (t.getMessage() != null) {
             session.putAttribute(flowFile, "markLogicErrorMessage", t.getMessage());
         }
-        transferAndCommit(session, flowFile, relationship);
     }
 
     protected void logError(Throwable t) {

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <maven.compiler.release>8</maven.compiler.release>
     <nifi.version>1.24.0</nifi.version>
     <marklogicnar.version>1.24.1</marklogicnar.version>
-    <marklogicclientapi.version>6.4.1</marklogicclientapi.version>
+    <marklogicclientapi.version>6.6.1</marklogicclientapi.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Testing verified that logging the IllegalStateException was very noisy and didn't add any value. 

There's no automated test for the change of not logging the stacktrace of an ISE though since the only change in behavior is that lack of logging. 

Also bumped up dependencies. 