### PR TITLE
MLE-14420 Added support for restarting batcher in PutMarkLogic

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
@@ -256,13 +256,13 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
      */
     protected final void logErrorAndTransfer(Throwable t, FlowFile flowFile, ProcessSession session, Relationship relationship) {
         logError(t);
-        addErrorMessageToFlowFile(t, flowFile, session);
+        addErrorMessageToFlowFile(t.getMessage(), flowFile, session);
         transferAndCommit(session, flowFile, relationship);
     }
 
-    protected final void addErrorMessageToFlowFile(Throwable t, FlowFile flowFile, ProcessSession session) {
-        if (t.getMessage() != null) {
-            session.putAttribute(flowFile, "markLogicErrorMessage", t.getMessage());
+    protected final void addErrorMessageToFlowFile(String message, FlowFile flowFile, ProcessSession session) {
+        if (message != null) {
+            session.putAttribute(flowFile, "markLogicErrorMessage", message);
         }
     }
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
@@ -129,6 +129,7 @@ public class PutMarkLogicRecord extends PutMarkLogic {
         list.add(URI_FIELD_NAME);
         list.add(URI_PREFIX);
         list.add(URI_SUFFIX);
+        list.add(RESTART_FAILED_BATCHER);
         properties = Collections.unmodifiableList(list);
 
         Set<Relationship> set = new HashSet<>();

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/QueryMarkLogic.java
@@ -405,7 +405,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
                 FlowFile flowFile = createFlowFileWithAttributes(session, incomingAttributes);
                 session.putAttribute(flowFile, CoreAttributes.FILENAME.key(), uri);
                 if (throwable != null) {
-                    session.putAttribute(flowFile, "markLogicErrorMessage", throwable.getMessage());
+                    addErrorMessageToFlowFile(throwable.getMessage(), flowFile, session);
                 }
                 session.transfer(flowFile, relationship);
             }
@@ -445,7 +445,7 @@ public class QueryMarkLogic extends AbstractMarkLogicProcessor {
                         // within the "try" block.
                         FlowFile flowFile = createFlowFileWithAttributes(session, incomingAttributes);
                         session.putAttribute(flowFile, CoreAttributes.FILENAME.key(), uri);
-                        session.putAttribute(flowFile, "markLogicErrorMessage", throwable.getMessage());
+                        addErrorMessageToFlowFile(throwable.getMessage(), flowFile, session);
                         session.transfer(flowFile, FAILURE);
                     }
                 });


### PR DESCRIPTION
Was not able to find a way to write an automated test for this without causing the processor itself to be restarted. So tested via the following manual process:

1. Load up the example flows per the CONTRIBUTING file.
2. Start the "Put Text" flow (after first setting the "Restart" property to "true").
3. Tail the NiFi log file to see "success" messages. 
4. Stop MarkLogic via Docker.
5. See the "failure" messages being logged.
6. Start MarkLogic via Docker.
7. See PutMarkLogic able to restart its WriteBatcher successfully and start logging "success" messages again. 