### PR TITLE
Fix BlackDuck and Polaris issues

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/DeleteMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/DeleteMarkLogic.java
@@ -54,7 +54,8 @@ public class DeleteMarkLogic extends QueryMarkLogic {
     @Override
     public void init(ProcessorInitializationContext context) {
         super.init(context);
-        List<PropertyDescriptor> list = new ArrayList<>();
+
+        final List<PropertyDescriptor> list = new ArrayList<>();
         list.add(DATABASE_CLIENT_SERVICE);
         list.add(BATCH_SIZE);
         list.add(THREAD_COUNT);
@@ -64,7 +65,7 @@ public class DeleteMarkLogic extends QueryMarkLogic {
         list.add(STATE_INDEX_TYPE);
         properties = Collections.unmodifiableList(list);
 
-        Set<Relationship> set = new HashSet<>();
+        final Set<Relationship> set = new HashSet<>();
         set.add(SUCCESS);
         set.add(FAILURE);
         set.add(ORIGINAL);

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
@@ -210,7 +210,7 @@ public class ExecuteScriptMarkLogic extends AbstractMarkLogicProcessor {
             if (contentVariable != null && contentVariable.length() > 0) {
                 final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
                 session.exportTo(incomingFlowFile, bytes);
-                final String content = bytes.toString();
+                final String content = bytes.toString(StandardCharsets.UTF_8);
 
                 call.addVariable(contentVariable, content);
             }

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
@@ -39,6 +39,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.stream.io.StreamUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -209,7 +210,7 @@ public class ExtensionCallMarkLogic extends AbstractMarkLogicProcessor {
                 requestBody.set(content);
                 break;
             case PayloadSources.PAYLOAD_PROPERTY_STR:
-                requestBody.set(context.getProperty(PAYLOAD).evaluateAttributeExpressions(flowFile).getValue().getBytes());
+                requestBody.set(context.getProperty(PAYLOAD).evaluateAttributeExpressions(flowFile).getValue().getBytes(StandardCharsets.UTF_8));
                 break;
         }
 

--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
@@ -146,8 +146,14 @@ public class PutMarkLogicRecord extends PutMarkLogic {
     public void initializeFactories(ProcessContext context) {
         recordReaderFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
         recordSetWriterFactory = context.getProperty(RECORD_WRITER).asControllerService(RecordSetWriterFactory.class);
-        coerceTypes = context.getProperty(RECORD_COERCE_TYPES).asBoolean();
-        dropUnknownFields = context.getProperty(RECORD_DROP_UNKNOWN_FIELDS).asBoolean();
+        if (context.getProperty(RECORD_COERCE_TYPES) != null &&
+            context.getProperty(RECORD_COERCE_TYPES).asBoolean() != null) {
+            coerceTypes = context.getProperty(RECORD_COERCE_TYPES).asBoolean();
+        }
+        if (context.getProperty(RECORD_DROP_UNKNOWN_FIELDS) != null &&
+            context.getProperty(RECORD_DROP_UNKNOWN_FIELDS).asBoolean() != null) {
+            dropUnknownFields = context.getProperty(RECORD_DROP_UNKNOWN_FIELDS).asBoolean();
+        }
     }
 
     @Override

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
@@ -26,6 +26,7 @@ import org.apache.nifi.util.*;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -87,7 +88,7 @@ public abstract class AbstractMarkLogicProcessorTest {
     }
 
     protected MockFlowFile addFlowFile(Map<String, String> attributes, String... contents) {
-        MockFlowFile flowFile = processSession.createFlowFile(String.join("\n", contents).getBytes(), attributes);
+        MockFlowFile flowFile = processSession.createFlowFile(String.join("\n", contents).getBytes(StandardCharsets.UTF_8), attributes);
         sharedSessionState.getFlowFileQueue().offer(flowFile);
         return flowFile;
     }

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/CallRestExtensionMarkLogicIT.java
@@ -5,6 +5,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,10 +33,10 @@ public class CallRestExtensionMarkLogicIT extends AbstractMarkLogicIT {
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(CallRestExtensionMarkLogic.RESULTS);
         assertEquals(2, results.size());
 
-        XmlNode firstDoc = new XmlNode(new String(runner.getContentAsByteArray(results.get(0))));
+        XmlNode firstDoc = new XmlNode(new String(runner.getContentAsByteArray(results.get(0)), StandardCharsets.UTF_8));
         assertEquals("doc1", firstDoc.getElementValue("/first"));
 
-        XmlNode secondDoc = new XmlNode(new String(runner.getContentAsByteArray(results.get(1))));
+        XmlNode secondDoc = new XmlNode(new String(runner.getContentAsByteArray(results.get(1)), StandardCharsets.UTF_8));
         assertEquals("doc2", secondDoc.getElementValue("/second"));
     }
 

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogicIT.java
@@ -21,6 +21,7 @@ import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,7 @@ public class ExecuteScriptMarkLogicIT extends AbstractMarkLogicIT {
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.RESULTS);
         assertEquals(1, results.size());
         runner.assertAllFlowFiles(ExecuteScriptMarkLogic.RESULTS, flowFile -> {
-            String resultValue = new String(runner.getContentAsByteArray((MockFlowFile) flowFile));
+            String resultValue = new String(runner.getContentAsByteArray((MockFlowFile) flowFile), StandardCharsets.UTF_8);
             assertEquals("2", resultValue, "The script is expected to return the value 2");
         });
     }
@@ -84,7 +85,7 @@ public class ExecuteScriptMarkLogicIT extends AbstractMarkLogicIT {
 
         assertEquals(1, runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.RESULTS).size());
         runner.assertAllFlowFiles(ExecuteScriptMarkLogic.RESULTS, flowFile -> {
-            String resultValue = new String(runner.getContentAsByteArray((MockFlowFile) flowFile));
+            String resultValue = new String(runner.getContentAsByteArray((MockFlowFile) flowFile), StandardCharsets.UTF_8);
             assertEquals("Hello world", resultValue);
         });
     }

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogicIT.java
@@ -21,6 +21,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,7 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS);
 
         MockFlowFile result = results.get(1);
-        String resultValue = new String(runner.getContentAsByteArray(result));
+        String resultValue = new String(runner.getContentAsByteArray(result), StandardCharsets.UTF_8);
         assertEquals("dynamic Value", resultValue,
             "The test 'replay' extension is expected to return the value of the 'replay' parameter, " +
                 "which is sent via the replay:param property. That property then has an expression, " +
@@ -91,7 +92,7 @@ public class ExtensionCallMarkLogicIT extends AbstractMarkLogicIT {
         List<MockFlowFile> results = runner.getFlowFilesForRelationship(ExtensionCallMarkLogic.SUCCESS);
         assertEquals(1, results.size());
         MockFlowFile result = results.get(0);
-        String resultValue = new String(runner.getContentAsByteArray(result));
+        String resultValue = new String(runner.getContentAsByteArray(result), StandardCharsets.UTF_8);
 
         assertEquals(testString + testString, resultValue);
     }

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicTest.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicTest.java
@@ -31,6 +31,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
 
         BytesHandle content = (BytesHandle) processor.writeEvent.getContent();
         assertEquals(Format.JSON, content.getFormat());
-        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get()));
+        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get(), StandardCharsets.UTF_8));
 
         DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
         assertEquals(4, metadata.getCollections().size());
@@ -90,7 +91,7 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
 
         BytesHandle content = (BytesHandle) processor.writeEvent.getContent();
         assertEquals(Format.JSON, content.getFormat());
-        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get()));
+        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get(), StandardCharsets.UTF_8));
 
         DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
         assertEquals(0, metadata.getCollections().size());
@@ -112,7 +113,7 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
 
         BytesHandle content = (BytesHandle) processor.writeEvent.getContent();
         assertEquals(Format.JSON, content.getFormat());
-        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get()));
+        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get(), StandardCharsets.UTF_8));
 
         DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
         assertEquals(0, metadata.getCollections().size());
@@ -134,7 +135,7 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
 
         BytesHandle content = (BytesHandle) processor.writeEvent.getContent();
         assertEquals(Format.JSON, content.getFormat());
-        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get()));
+        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get(), StandardCharsets.UTF_8));
 
         DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
         assertEquals(0, metadata.getCollections().size());
@@ -162,7 +163,7 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
 
         BytesHandle content = (BytesHandle) processor.writeEvent.getContent();
         assertEquals(Format.JSON, content.getFormat());
-        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get()));
+        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get(), StandardCharsets.UTF_8));
 
         DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
         assertEquals(0, metadata.getCollections().size());
@@ -184,7 +185,7 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
 
         BytesHandle content = (BytesHandle) processor.writeEvent.getContent();
         assertEquals(Format.JSON, content.getFormat());
-        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get()));
+        assertEquals("{\"hello\":\"nifi rocks\"}", new String(content.get(), StandardCharsets.UTF_8));
 
         DocumentMetadataHandle metadata = (DocumentMetadataHandle) processor.writeEvent.getMetadata();
         assertEquals(2, metadata.getCollections().size());
@@ -295,7 +296,7 @@ public class PutMarkLogicTest extends AbstractMarkLogicProcessorTest {
 
         BytesHandle content = (BytesHandle) processor.writeEvent.getContent();
         assertEquals(Format.XML, content.getFormat());
-        assertEquals("<test/>", new String(content.get()));
+        assertEquals("<test/>", new String(content.get(), StandardCharsets.UTF_8));
     }
 
     @Test

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
@@ -43,18 +43,14 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class QueryMarkLogicIT extends AbstractMarkLogicIT {
 
@@ -148,7 +144,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes(StandardCharsets.UTF_8);
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertArrayEquals(expectedByteArray, actualByteArray);
     }
@@ -190,7 +186,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes(StandardCharsets.UTF_8);
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertArrayEquals(expectedByteArray, actualByteArray);
     }
@@ -396,7 +392,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes(StandardCharsets.UTF_8);
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertArrayEquals(expectedByteArray, actualByteArray);
         runner.shutdown();
@@ -407,7 +403,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         TestRunner runner = getNewTestRunner(QueryMarkLogic.class);
         Map<String, String> attributes = new HashMap<>();
         attributes.put("word", "xmlcontent");
-        runner.enqueue("".getBytes(), attributes);
+        runner.enqueue("".getBytes(StandardCharsets.UTF_8), attributes);
         runner.setProperty(QueryMarkLogic.QUERY, "<query xmlns=\"http://marklogic.com/appservices/search\">\n" +
             "  <word-query>\n" +
             "    <element name=\"sample\" ns=\"\" />\n" +
@@ -435,7 +431,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes(StandardCharsets.UTF_8);
 
         assertBytesAreEqualXMLDocs(expectedByteArray, actualByteArray);
         runner.shutdown();
@@ -459,7 +455,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes(StandardCharsets.UTF_8);
 
         assertBytesAreEqualXMLDocs(expectedByteArray, actualByteArray);
         runner.shutdown();
@@ -667,6 +663,9 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
     }
 
     private void assertBytesAreEqualXMLDocs(byte[] expectedByteArray, byte[] actualByteArray) {
+
+        assertNotNull(expectedByteArray, "The expectedByteArray is null");
+        assertNotNull(actualByteArray, "The actualByteArray is null");
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
@@ -743,7 +742,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(xmlMod).getContent().getBytes(StandardCharsets.UTF_8);
 
         assertBytesAreEqualXMLDocs(expectedByteArray, actualByteArray);
         runner.shutdown();
@@ -769,7 +768,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
                 break;
             }
         }
-        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes();
+        byte[] expectedByteArray = documents.get(jsonMod).getContent().getBytes(StandardCharsets.UTF_8);
         assertEquals(expectedByteArray.length, actualByteArray.length);
         assertArrayEquals(expectedByteArray, actualByteArray);
         runner.shutdown();

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryRowsMarkLogicIT.java
@@ -8,6 +8,7 @@ import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,7 @@ public class QueryRowsMarkLogicIT extends AbstractMarkLogicIT {
         assertEquals(1, files.size(), "A single FlowFile with the TDE response should have been transferred");
 
         // Newline characters are making it difficult to assert on the entire response at once
-        final String response = new String(files.get(0).toByteArray());
+        final String response = new String(files.getFirst().toByteArray(),StandardCharsets.UTF_8);
         assertTrue(response.startsWith("Example.default.Id"));
         assertTrue(response.contains("0"));
         assertTrue(response.contains("1"));
@@ -153,10 +154,10 @@ public class QueryRowsMarkLogicIT extends AbstractMarkLogicIT {
 
         List<MockFlowFile> list = runner.getFlowFilesForRelationship(QueryRowsMarkLogic.ORIGINAL);
         assertEquals(Integer.valueOf(1), list.size(), "The new incoming FlowFile should go to Original");
-        assertEquals(serializedPlan, list.get(0).getAttribute("marklogic-optic-plan"), "The serialized plan should be" +
+        assertEquals(serializedPlan, list.getFirst().getAttribute("marklogic-optic-plan"), "The serialized plan should be" +
             " on the success FlowFile so that a user knows what was executed to produce the rows");
 
-        final String response = new String(list.get(0).toByteArray());
+        final String response = new String(list.getFirst().toByteArray(), StandardCharsets.UTF_8);
         assertEquals("", response, "The response should be empty since the 'where' clause resulted in no rows being " +
             "found; no error should be thrown either, as the serialized plan is valid; it just doesn't match anything");
 

--- a/nifi-marklogic-services-api/pom.xml
+++ b/nifi-marklogic-services-api/pom.xml
@@ -45,6 +45,28 @@
       <groupId>com.marklogic</groupId>
       <artifactId>ml-javaclient-util</artifactId>
       <version>5.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-aop</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-beans</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Remove flagged but unnecessary Spring components for deps ml-javaclient-util and data-hub. Only direct dependency was FileCopyUtils.copy which was easy to replicate as a util function in the class. Just a in->out stream copy and close.

Check for nulls to avoid runtime NPE. Rare but flagged.

Use character encoding when serializing/deserializing strings.