### PR TITLE
MLE-29543: Bump nifi version to 2.9.0 to avoid CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The MarkLogic NiFi connector simplifies integrating [Apache NiFi](https://nifi.apache.org/) with MarkLogic, allowing for 
 data to be easily written to and read from MarkLogic. The connector consists of a set of custom NiFi processors and 
 controller services which can be used in NiFi flows for integrating with MarkLogic. The connector has been developed 
-and tested on NiFi 2.5.0; it may work in more recent versions of NiFi too. 
+and tested on NiFi 2.9.0; it may work with other NiFi 2.x versions as well.
 
 Please see the [Getting Started guide](https://marklogic.github.io/nifi/getting-started) 
 for information on obtaining the connector, installing it, and using it. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ export data to and from MarkLogic, along with running batch processes on data al
 The connector has the following system requirements:
 
 * Apache NiFi 2.0 or higher; the connector may run successfully on earlier versions of NiFi but it is only 
-  actively tested on NiFi 2.5.0 and higher.
+  actively tested on NiFi 2.9.0 and higher.
 * MarkLogic 10 or higher, though processors that do not depend on any functionality in MarkLogic 10 or later will 
   run fine on MarkLogic 9.
 

--- a/nifi-marklogic-processors/flows-for-manual-testing.json
+++ b/nifi-marklogic-processors/flows-for-manual-testing.json
@@ -34,7 +34,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "ORIGINAL",
@@ -153,7 +153,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "FAILURE",
@@ -272,7 +272,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "RESULTS",
@@ -642,7 +642,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "FAILURE!!!!",
@@ -761,7 +761,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "QUERY RESULT",
@@ -1137,7 +1137,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "character-set": "UTF-8",
@@ -1230,7 +1230,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "AFTER:",
@@ -1649,7 +1649,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "RESULTS",
@@ -1866,7 +1866,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "LOGERROR!!!",
@@ -1985,7 +1985,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "character-set": "UTF-8",
@@ -2078,7 +2078,7 @@
                         "bundle": {
                             "group": "org.apache.nifi",
                             "artifact": "nifi-standard-nar",
-                            "version": "2.5.0"
+                            "version": "2.9.0"
                         },
                         "properties": {
                             "Log prefix": "ORIGINAL",

--- a/nifi-marklogic-processors/pom.xml
+++ b/nifi-marklogic-processors/pom.xml
@@ -187,7 +187,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.5.5</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-extension-bundles</artifactId>
-    <version>2.5.0</version>
+    <version>2.9.0</version>
   </parent>
 
   <version>2.0.0</version>
@@ -33,7 +33,7 @@
   <properties>
     <!-- Nifi 2 requires Java 21 -->
     <maven.compiler.release>21</maven.compiler.release>
-    <nifi.version>2.5.0</nifi.version>
+    <nifi.version>${project.parent.version}</nifi.version>
     <marklogicnar.version>2.0.0</marklogicnar.version>
     <marklogicclientapi.version>8.0.0</marklogicclientapi.version>
     <spring.version>6.2.15</spring.version>


### PR DESCRIPTION
Upgrade Nifi to 2.9.0. Compatible incremental release, no code changes required. Transitive dependencies in Nifi updated to clear CVEs.